### PR TITLE
Fix BazelPhaseDescriptions#getSummary bug

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
@@ -71,8 +71,6 @@ public class BazelPhaseDescriptions implements Datum {
                 phase.name));
       }
     }
-    // Remove the final newline
-    sb.setLength(sb.length() - 1);
     return sb.toString();
   }
 }


### PR DESCRIPTION
Previoulsy, the code had an additional newline, which we removed. After the last refactoring we avoided that newline, but forgot to delete the code that removes it. This PR does that.