### PR TITLE
Harden CriticalPathNotDominantSuggestionProvider

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
@@ -35,6 +35,10 @@ public class BazelPhaseDescriptions implements Datum {
     return phaseToDescription.get(phase);
   }
 
+  public boolean has(BazelProfilePhase phase) {
+    return phaseToDescription.containsKey(phase);
+  }
+
   @Override
   public String getDescription() {
     return "The Bazel Profile's various phases and their timing information.";

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProvider.java
@@ -52,6 +52,11 @@ public class CriticalPathNotDominantSuggestionProvider extends SuggestionProvide
   public SuggestionOutput getSuggestions(DataManager dataManager) {
     try {
       BazelPhaseDescriptions phases = dataManager.getDatum(BazelPhaseDescriptions.class);
+      if (!phases.has(BazelProfilePhase.EXECUTE)) {
+        // No execution phase found, so critical path analysis not applicable.
+        return SuggestionProviderUtil.createSuggestionOutput(ANALYZER_CLASSNAME, null, null);
+      }
+
       Duration executionDuration = phases.get(BazelProfilePhase.EXECUTE).getDuration();
       if (executionDuration.compareTo(MIN_DURATION_FOR_EVALUATION) < 0) {
         Caveat caveat =

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
@@ -71,6 +71,18 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   }
 
   @Test
+  public void shouldNotReturnSuggestionForMissingExecutionPhase() throws Exception {
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+    verify(dataManager).getDatum(BazelPhaseDescriptions.class);
+    verifyNoMoreInteractions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+
+  @Test
   public void shouldNotReturnSuggestionForTooShortExecutionPhase() throws Exception {
     phases.add(
         BazelProfilePhase.EXECUTE,


### PR DESCRIPTION
Fixes #12

Fixes a NPE when the Bazel profile does not include a marker for the execution phase.
We now check whether BazelProfilePhase.EXECUTE exists before accessing it. If not, no evaluation can be made and we return no suggestions.