### PR TITLE
Harden ActionStatsDataProvider

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProvider.java
@@ -38,6 +38,9 @@ public class ActionStatsDataProvider extends DataProvider {
     BazelProfile bazelProfile = getDataManager().getDatum(BazelProfile.class);
     var actionCounts =
         bazelProfile.getMainThread().getCounts().get(BazelProfileConstants.COUNTER_ACTION_COUNT);
+    if (actionCounts == null) {
+      return new ActionStats(List.of());
+    }
 
     var coreCount = getDataManager().getDatum(EstimatedCoresUsed.class).getEstimatedCores();
 

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProviderTest.java
@@ -46,6 +46,13 @@ public class ActionStatsDataProviderTest extends DataProviderUnitTestBase {
   }
 
   @Test
+  public void shouldReturnNoBottlenecksOnEmptyProfile()
+      throws DuplicateProviderException, MissingInputException, InvalidProfileException {
+    useProfile(metaData(), trace(thread(0, 0, BazelProfileConstants.THREAD_MAIN)));
+    assertThat(provider.getActionStats().bottlenecks).isEmpty();
+  }
+
+  @Test
   public void shouldCaptureBottleneckRunningSingleAction()
       throws DuplicateProviderException, MissingInputException, InvalidProfileException {
     useCoreCount(4);


### PR DESCRIPTION
Fixes #14

Check whether action count exists before accessing it. If no such count exists, no bottlenecks can be detected.