### PR TITLE
Fix incorrect identification of RemoteExecutionUsed

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
@@ -33,6 +33,11 @@ public class BazelProfileConstants {
   public static final String CAT_REMOTE_EXECUTION_PROCESS_WALL_TIME =
       "Remote execution process wall time";
   public static final String CAT_REMOTE_EXECUTION_QUEUING_TIME = "Remote execution queuing time";
+  public static final String CAT_REMOTE_EXECUTION_SETUP = "Remote execution setup";
+  /**
+   * This event does not necessarily imply remote execution was enabled. For example, it is also
+   * reported when setting the Bazel flag `--disk_cache`.
+   */
   public static final String CAT_REMOTE_EXECUTION_UPLOAD_TIME = "Remote execution upload time";
 
   // CompleteEvent names

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProvider.java
@@ -47,8 +47,10 @@ public class RemoteExecutionUsedDataProvider extends DataProvider {
             .flatMap((thread) -> thread.getCompleteEvents().stream())
             .anyMatch(
                 (event) ->
-                    BazelProfileConstants.CAT_REMOTE_EXECUTION_UPLOAD_TIME.equals(event.category)
+                    BazelProfileConstants.CAT_REMOTE_EXECUTION_SETUP.equals(event.category)
                         || BazelProfileConstants.CAT_REMOTE_EXECUTION_PROCESS_WALL_TIME.equals(
+                            event.category)
+                        || BazelProfileConstants.CAT_REMOTE_EXECUTION_QUEUING_TIME.equals(
                             event.category)));
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
@@ -8,6 +8,7 @@ java_test(
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/core",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution:types",
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//analyzer/javatests/com/engflow/bazel/invocation/analyzer:test_base",
         "//analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders:data_provider_test_base",
         "//third_party/junit",


### PR DESCRIPTION
Fixes #6
Progress on #17

Previously any Bazel profile with an event of category "Remote execution upload time" was classified as using remote execution. However, such events are also reported when running bazel with `--disk_cache`. Instead focus on other events, which do not seem to be reported for invocations with `--disk_cache` that do not use remote execution.