### PR TITLE
BottleneckSuggestionProvider: set default minImprovementRatio to 5%

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
@@ -180,7 +180,7 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
   }
 
   public static BottleneckSuggestionProvider createDefault() {
-    return new BottleneckSuggestionProvider(5, 5, Duration.ofSeconds(5), .01);
+    return new BottleneckSuggestionProvider(5, 5, Duration.ofSeconds(5), .05);
   }
 
   public static BottleneckSuggestionProvider createVerbose() {


### PR DESCRIPTION
Returning bottlenecks that may speed up the invocation by just 1% seems too insignificant. Increase the default `minImprovementRatio` to 5%.