### PR TITLE
CLI: support relative paths for passed in Bazel profile

### DIFF
--- a/cli/java/com/engflow/bazel/invocation/analyzer/Main.java
+++ b/cli/java/com/engflow/bazel/invocation/analyzer/Main.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Locale;
 
 public class Main {
+  private static final String BUILD_WORKING_DIRECTORY = "BUILD_WORKING_DIRECTORY";
+
   public static void main(String[] args) throws Exception {
     IaOptions options = new IaOptions(args);
 
@@ -70,13 +72,25 @@ public class Main {
       String bazelProfilePath = options.getArguments()[0];
       File file = new File(bazelProfilePath);
       if (!file.isAbsolute()) {
-        String buildWorkingDirectory = System.getenv("BUILD_WORKING_DIRECTORY");
+        String buildWorkingDirectory = System.getenv(BUILD_WORKING_DIRECTORY);
         if (buildWorkingDirectory != null) {
-          bazelProfilePath =
+          String absoluteBazelProfilePath =
               buildWorkingDirectory + FileSystems.getDefault().getSeparator() + bazelProfilePath;
+          String relativePathWarning =
+              String.format(
+                  "The relative path\n\t%s\nwas resolved to\n\t%s\nusing the value of the"
+                      + " environment variable\n\t%s=%s\nIf this is undesired, specify"
+                      + " an absolute path instead.",
+                  bazelProfilePath,
+                  absoluteBazelProfilePath,
+                  BUILD_WORKING_DIRECTORY,
+                  buildWorkingDirectory);
+          consoleOutput.outputNote(relativePathWarning);
+          bazelProfilePath = absoluteBazelProfilePath;
+          file = new File(bazelProfilePath);
         }
       }
-      consoleOutput.outputAnalysisInput(bazelProfilePath);
+      consoleOutput.outputAnalysisInput(file.getCanonicalPath());
 
       DataManager dataManager = new DataManager();
       BazelProfile bazelProfile = BazelProfile.createFromPath(bazelProfilePath);

--- a/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
+++ b/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
@@ -65,8 +65,15 @@ public class ConsoleOutput {
     System.out.println();
   }
 
+  public void outputNote(String warning) {
+    System.out.println(format("Note:", ConsoleOutputStyle.TEXT_BOLD));
+    System.out.println(warning);
+    System.out.println();
+  }
+
   public void outputAnalysisInput(String inputDescription) {
-    System.out.printf("Analyzing %s\n", inputDescription);
+    System.out.printf("Analyzing %s", inputDescription);
+    System.out.println();
   }
 
   public void outputSuggestions(Stream<SuggestionOutput> suggestions) {
@@ -167,7 +174,7 @@ public class ConsoleOutput {
     if (suggestionOutput.hasFailure()) {
       SuggestionOutput.Failure failure = suggestionOutput.getFailure();
       sb.append(failure.getMessage());
-      sb.append("\n");
+      sb.append(NEWLINE);
       if (verbose) {
         sb.append(failure.getStackTrace());
       }
@@ -199,7 +206,7 @@ public class ConsoleOutput {
         if (!Strings.isNullOrEmpty(message)) {
           improvementMessages.add(message);
         }
-        addSection(sb, HEADING_POTENTIAL_IMPROVEMENT, String.join("\n", improvementMessages));
+        addSection(sb, HEADING_POTENTIAL_IMPROVEMENT, String.join(NEWLINE, improvementMessages));
       }
       addSection(sb, HEADING_RATIONALE, suggestion.getRationaleList());
       List<String> formattedCaveats =


### PR DESCRIPTION
Addresses #5 

Currently, when running the tool with `bazel run //cli -- /path/to/profile.json` an absolute path needs to be passed in, as the binary is executed from the runfiles directory.

This change adds support for relative paths:
If the path passed in is relative and the environment variable `$BUILD_WORKING_DIRECTORY` is set, then the value of that variable is prepended to the path to make it absolute.
`bazel run` sets this environment variable.

With this change, these commands read the file from the correct location (tested under macOS):
```bash
bazel run //cli -- relative/path/to/profile.json

bazel run --run_under="cd $PWD && " //cli -- relative/path/to/profile.json
```

However,
```bash
export BUILD_WORKING_DIRECTORY=/nonexistent/path && bazel build //cli:cli_deploy.jar && java -jar bazel-bin/cli/cli_deploy.jar relative/path/to/profile.json
```
no longer works.