### PR TITLE
CLI: Exit on relative paths

### DIFF
--- a/cli/java/com/engflow/bazel/invocation/analyzer/Main.java
+++ b/cli/java/com/engflow/bazel/invocation/analyzer/Main.java
@@ -24,6 +24,7 @@ import com.engflow.bazel.invocation.analyzer.options.IaOption;
 import com.engflow.bazel.invocation.analyzer.options.IaOptions;
 import com.engflow.bazel.invocation.analyzer.options.Mode;
 import com.engflow.bazel.invocation.analyzer.suggestionproviders.SuggestionProviderUtil;
+import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -67,7 +68,12 @@ public class Main {
     try {
 
       String bazelProfilePath = options.getArguments()[0];
-      consoleOutput.outputAnalysisInput(bazelProfilePath);
+      File file = new File(bazelProfilePath);
+      if (!file.isAbsolute()) {
+        consoleOutput.outputRelativePathError(bazelProfilePath);
+        System.exit(1);
+      }
+      consoleOutput.outputAnalysisInput(file.getCanonicalPath());
 
       DataManager dataManager = new DataManager();
       BazelProfile bazelProfile = BazelProfile.createFromPath(bazelProfilePath);

--- a/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
+++ b/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
@@ -65,8 +65,15 @@ public class ConsoleOutput {
     System.out.println();
   }
 
+  public void outputRelativePathError(String relativePath) {
+    System.out.println(
+        format("You provided a relative path to the Bazel profile:", ConsoleOutputStyle.TEXT_RED));
+    System.out.println(relativePath);
+    System.out.println(format("Specify an absolute path instead.", ConsoleOutputStyle.TEXT_RED));
+  }
+
   public void outputAnalysisInput(String inputDescription) {
-    System.out.printf("Analyzing %s\n", inputDescription);
+    System.out.printf("Analyzing %s%s", inputDescription, NEWLINE);
   }
 
   public void outputSuggestions(Stream<SuggestionOutput> suggestions) {
@@ -167,7 +174,7 @@ public class ConsoleOutput {
     if (suggestionOutput.hasFailure()) {
       SuggestionOutput.Failure failure = suggestionOutput.getFailure();
       sb.append(failure.getMessage());
-      sb.append("\n");
+      sb.append(NEWLINE);
       if (verbose) {
         sb.append(failure.getStackTrace());
       }
@@ -199,7 +206,7 @@ public class ConsoleOutput {
         if (!Strings.isNullOrEmpty(message)) {
           improvementMessages.add(message);
         }
-        addSection(sb, HEADING_POTENTIAL_IMPROVEMENT, String.join("\n", improvementMessages));
+        addSection(sb, HEADING_POTENTIAL_IMPROVEMENT, String.join(NEWLINE, improvementMessages));
       }
       addSection(sb, HEADING_RATIONALE, suggestion.getRationaleList());
       List<String> formattedCaveats =


### PR DESCRIPTION
Related to #5

* check for relative paths of passed in Bazel profile
* print error message if relative and exit
* print out canonical path for passed in paths that are absolute