### PR TITLE
Refactor BazelPhaseDescriptions

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
@@ -17,6 +17,7 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfilePhase;
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,10 +26,14 @@ import java.util.Map;
  * Bazel profile.
  */
 public class BazelPhaseDescriptions implements Datum {
-  private final Map<BazelProfilePhase, BazelPhaseDescription> phaseToDescription = new HashMap<>();
+  private final ImmutableMap<BazelProfilePhase, BazelPhaseDescription> phaseToDescription;
 
-  public void add(BazelProfilePhase phase, BazelPhaseDescription description) {
-    phaseToDescription.put(phase, description);
+  private BazelPhaseDescriptions(Map<BazelProfilePhase, BazelPhaseDescription> phaseToDescription) {
+    this.phaseToDescription = ImmutableMap.copyOf(phaseToDescription);
+  }
+
+  public static BazelPhaseDescriptions.Builder newBuilder() {
+    return new BazelPhaseDescriptions.Builder();
   }
 
   public BazelPhaseDescription get(BazelProfilePhase phase) {
@@ -102,5 +107,22 @@ public class BazelPhaseDescriptions implements Datum {
       }
     }
     return sb.toString();
+  }
+
+  public static class Builder {
+    private final Map<BazelProfilePhase, BazelPhaseDescription> phaseToDescription;
+
+    private Builder() {
+      this.phaseToDescription = new HashMap<>();
+    }
+
+    public Builder add(BazelProfilePhase phase, BazelPhaseDescription description) {
+      phaseToDescription.put(phase, description);
+      return this;
+    }
+
+    public BazelPhaseDescriptions build() {
+      return new BazelPhaseDescriptions(phaseToDescription);
+    }
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProvider.java
@@ -149,17 +149,18 @@ public class BazelPhasesDataProvider extends DataProvider {
       }
     }
 
-    BazelPhaseDescriptions result = new BazelPhaseDescriptions();
+    BazelPhaseDescriptions.Builder resultBuilder = BazelPhaseDescriptions.newBuilder();
     Timestamp previousTimestamp = launchStart;
     BazelProfilePhase previousPhase = BazelProfilePhase.LAUNCH;
     for (Timestamp timestamp : startToPhase.keySet()) {
       if (previousPhase != null) {
-        result.add(previousPhase, new BazelPhaseDescription(previousTimestamp, timestamp));
+        resultBuilder.add(previousPhase, new BazelPhaseDescription(previousTimestamp, timestamp));
       }
       previousTimestamp = timestamp;
       previousPhase = startToPhase.get(timestamp);
     }
-    result.add(BazelProfilePhase.FINISH, new BazelPhaseDescription(previousTimestamp, finishEnd));
-    return result;
+    resultBuilder.add(
+        BazelProfilePhase.FINISH, new BazelPhaseDescription(previousTimestamp, finishEnd));
+    return resultBuilder.build();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptionsTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptionsTest.java
@@ -25,8 +25,8 @@ public class BazelPhaseDescriptionsTest {
   public void getOrClosestBeforeShouldReturnSelf() {
     BazelPhaseDescription description =
         new BazelPhaseDescription(Timestamp.ofMicros(1), Timestamp.ofMicros(2));
-    BazelPhaseDescriptions descriptions = new BazelPhaseDescriptions();
-    descriptions.add(BazelProfilePhase.EVALUATE, description);
+    BazelPhaseDescriptions descriptions =
+        BazelPhaseDescriptions.newBuilder().add(BazelProfilePhase.EVALUATE, description).build();
     assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.EVALUATE)).isEqualTo(description);
   }
 
@@ -36,17 +36,19 @@ public class BazelPhaseDescriptionsTest {
         new BazelPhaseDescription(Timestamp.ofMicros(1), Timestamp.ofMicros(2));
     BazelPhaseDescription otherDescription =
         new BazelPhaseDescription(Timestamp.ofMicros(5), Timestamp.ofMicros(8));
-    BazelPhaseDescriptions descriptions = new BazelPhaseDescriptions();
-    descriptions.add(BazelProfilePhase.INIT, otherDescription);
-    descriptions.add(BazelProfilePhase.EVALUATE, expectedDescription);
-    descriptions.add(BazelProfilePhase.PREPARE, otherDescription);
+    BazelPhaseDescriptions descriptions =
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.INIT, otherDescription)
+            .add(BazelProfilePhase.EVALUATE, expectedDescription)
+            .add(BazelProfilePhase.PREPARE, otherDescription)
+            .build();
     assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.DEPENDENCIES))
         .isEqualTo(expectedDescription);
   }
 
   @Test
   public void getOrClosestBeforeShouldReturnNull() {
-    BazelPhaseDescriptions descriptions = new BazelPhaseDescriptions();
+    BazelPhaseDescriptions descriptions = BazelPhaseDescriptions.newBuilder().build();
     assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.EVALUATE)).isNull();
   }
 
@@ -54,8 +56,8 @@ public class BazelPhaseDescriptionsTest {
   public void getOrClosestAfterShouldReturnSelf() {
     BazelPhaseDescription description =
         new BazelPhaseDescription(Timestamp.ofMicros(1), Timestamp.ofMicros(2));
-    BazelPhaseDescriptions descriptions = new BazelPhaseDescriptions();
-    descriptions.add(BazelProfilePhase.EVALUATE, description);
+    BazelPhaseDescriptions descriptions =
+        BazelPhaseDescriptions.newBuilder().add(BazelProfilePhase.EVALUATE, description).build();
     assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE)).isEqualTo(description);
   }
 
@@ -65,17 +67,19 @@ public class BazelPhaseDescriptionsTest {
         new BazelPhaseDescription(Timestamp.ofMicros(1), Timestamp.ofMicros(2));
     BazelPhaseDescription otherDescription =
         new BazelPhaseDescription(Timestamp.ofMicros(5), Timestamp.ofMicros(8));
-    BazelPhaseDescriptions descriptions = new BazelPhaseDescriptions();
-    descriptions.add(BazelProfilePhase.INIT, otherDescription);
-    descriptions.add(BazelProfilePhase.PREPARE, expectedDescription);
-    descriptions.add(BazelProfilePhase.EXECUTE, otherDescription);
+    BazelPhaseDescriptions descriptions =
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.INIT, otherDescription)
+            .add(BazelProfilePhase.PREPARE, expectedDescription)
+            .add(BazelProfilePhase.EXECUTE, otherDescription)
+            .build();
     assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE))
         .isEqualTo(expectedDescription);
   }
 
   @Test
   public void getOrClosestAfterShouldReturnNull() {
-    BazelPhaseDescriptions descriptions = new BazelPhaseDescriptions();
+    BazelPhaseDescriptions descriptions = BazelPhaseDescriptions.newBuilder().build();
     assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE)).isNull();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
@@ -62,11 +62,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(2, within, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase, within, Duration.ZERO)));
 
-    BazelPhaseDescriptions bazelPhaseDescriptions = new BazelPhaseDescriptions();
-    bazelPhaseDescriptions.add(
-        BazelProfilePhase.EVALUATE, new BazelPhaseDescription(start, within));
-    bazelPhaseDescriptions.add(
-        BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(within, end));
+    BazelPhaseDescriptions bazelPhaseDescriptions =
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.EVALUATE, new BazelPhaseDescription(start, within))
+            .add(BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(within, end))
+            .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
@@ -89,11 +89,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(maxIndexInRelevantPhase, end, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
 
-    BazelPhaseDescriptions bazelPhaseDescriptions = new BazelPhaseDescriptions();
-    bazelPhaseDescriptions.add(
-        BazelProfilePhase.EVALUATE, new BazelPhaseDescription(start, within));
-    bazelPhaseDescriptions.add(
-        BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(within, end));
+    BazelPhaseDescriptions bazelPhaseDescriptions =
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.EVALUATE, new BazelPhaseDescription(start, within))
+            .add(BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(within, end))
+            .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
@@ -115,9 +115,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
 
-    BazelPhaseDescriptions bazelPhaseDescriptions = new BazelPhaseDescriptions();
-    bazelPhaseDescriptions.add(BazelProfilePhase.INIT, new BazelPhaseDescription(start, within1));
-    bazelPhaseDescriptions.add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(within2, end));
+    BazelPhaseDescriptions bazelPhaseDescriptions =
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.INIT, new BazelPhaseDescription(start, within1))
+            .add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(within2, end))
+            .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
@@ -136,8 +138,10 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(1, start, Duration.ZERO),
             skyFrameThread(2, start, Duration.ZERO),
             skyFrameThread(3, start, Duration.ZERO)));
-    BazelPhaseDescriptions bazelPhaseDescriptions = new BazelPhaseDescriptions();
-    bazelPhaseDescriptions.add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(start, end));
+    BazelPhaseDescriptions bazelPhaseDescriptions =
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(start, end))
+            .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
@@ -158,8 +162,10 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(1, start, Duration.ZERO),
             skyFrameThread(2, start, Duration.ZERO),
             skyFrameThread(3, outsideRangeBefore, Duration.ZERO)));
-    BazelPhaseDescriptions bazelPhaseDescriptions = new BazelPhaseDescriptions();
-    bazelPhaseDescriptions.add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(start, end));
+    BazelPhaseDescriptions bazelPhaseDescriptions =
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(start, end))
+            .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
@@ -182,10 +188,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(1, within2, Duration.ZERO),
             skyFrameThread(2, outsideRangeAfter, Duration.ZERO),
             skyFrameThread(3, within1, Duration.ZERO)));
-    BazelPhaseDescriptions bazelPhaseDescriptions = new BazelPhaseDescriptions();
-    bazelPhaseDescriptions.add(
-        BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(start, within1));
-    bazelPhaseDescriptions.add(BazelProfilePhase.FINISH, new BazelPhaseDescription(within2, end));
+    BazelPhaseDescriptions bazelPhaseDescriptions =
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(start, within1))
+            .add(BazelProfilePhase.FINISH, new BazelPhaseDescription(within2, end))
+            .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
@@ -16,8 +16,6 @@ package com.engflow.bazel.invocation.analyzer.suggestionproviders;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
@@ -41,7 +39,7 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   // are set up with reasonable defaults before each test is run, but can be overridden within the
   // tests when custom values are desired for the testing being conducted (without the need to
   // re-initialize the mocking).
-  private BazelPhaseDescriptions phases;
+  private BazelPhaseDescriptions.Builder phases;
   @Nullable private CriticalPathDuration criticalPathDuration;
   private TotalDuration totalDuration;
   private RemoteExecutionUsed remoteExecutionUsed;
@@ -54,8 +52,8 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
 
     // Create reasonable defaults and set up to return the class-variables when the associated types
     // are requested.
-    phases = new BazelPhaseDescriptions();
-    when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(phases);
+    phases = BazelPhaseDescriptions.newBuilder();
+    when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenAnswer(i -> phases.build());
     criticalPathDuration = new CriticalPathDuration(Duration.ofSeconds(10));
     when(dataManager.getDatum(CriticalPathDuration.class)).thenAnswer(i -> criticalPathDuration);
     totalDuration = new TotalDuration(Duration.ofSeconds(100));
@@ -79,9 +77,6 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
     criticalPathDuration = null;
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    verify(dataManager).getDatum(BazelPhaseDescriptions.class);
-    verify(dataManager).getDatum(CriticalPathDuration.class);
-    verifyNoMoreInteractions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
@@ -92,8 +87,6 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   @Test
   public void shouldNotReturnSuggestionForMissingExecutionPhase() throws Exception {
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    verify(dataManager).getDatum(BazelPhaseDescriptions.class);
-    verifyNoMoreInteractions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
@@ -108,8 +101,6 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
         new BazelPhaseDescription(Timestamp.ofMicros(0), Timestamp.ofSeconds(1)));
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    verify(dataManager).getDatum(BazelPhaseDescriptions.class);
-    verifyNoMoreInteractions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
@@ -128,9 +119,6 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
     criticalPathDuration = new CriticalPathDuration(criticalPath);
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    verify(dataManager).getDatum(BazelPhaseDescriptions.class);
-    verify(dataManager).getDatum(CriticalPathDuration.class);
-    verifyNoMoreInteractions(dataManager);
 
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProviderTest.java
@@ -35,7 +35,7 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
   // tests when custom values are desired for the testing being conducted (without the need to
   // re-initialize the mocking).
   private TotalDuration totalDuration;
-  private BazelPhaseDescriptions bazelPhaseDescriptions;
+  private BazelPhaseDescriptions.Builder bazelPhaseDescriptions;
 
   @Before
   public void setup() throws Exception {
@@ -43,9 +43,9 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
     // are requested.
     totalDuration = new TotalDuration(Duration.ofSeconds(60));
     when(dataManager.getDatum(TotalDuration.class)).thenAnswer(i -> totalDuration);
-    bazelPhaseDescriptions = new BazelPhaseDescriptions();
+    bazelPhaseDescriptions = BazelPhaseDescriptions.newBuilder();
     when(dataManager.getDatum(BazelPhaseDescriptions.class))
-        .thenAnswer(i -> bazelPhaseDescriptions);
+        .thenAnswer(i -> bazelPhaseDescriptions.build());
 
     suggestionProvider = new NegligiblePhaseSuggestionProvider();
   }


### PR DESCRIPTION
Make `BazelPhaseDescriptions` immutable and introduce a Builder for it. This is to ensure that the object cannot be modified by other `DataProvider`s or `SuggestionProvider`s.

Also see #22