### PR TITLE
CLI: Link to GitHub issues overview page

### DIFF
--- a/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
+++ b/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
@@ -59,7 +59,7 @@ public class ConsoleOutput {
       "Bazel Invocation Analyzer is open source. We welcome contributions!";
   private static final String TAB = "\t";
   private static final String FEEDBACK_OPEN_NEW_ISSUE =
-      "https://github.com/EngFlow/bazel_invocation_analyzer/issues/new/choose";
+      "https://github.com/EngFlow/bazel_invocation_analyzer/issues";
   private static final String FEEDBACK_EMAIL_ADDRESS = "bia-dev@engflow.com";
 
   private final boolean disableFormatting;


### PR DESCRIPTION
Followup to #33

Instead of linking to the page to create a new issue, link to the page listing all issues. This encourages issue reporters to first check / search for issues to avoid duplicates.