### PR TITLE
TotalDuration: return Optional<Duration>

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/core/DataManager.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/core/DataManager.java
@@ -55,7 +55,7 @@ public class DataManager {
 
     Object datum = entry.supplier.supply();
     if (datum == null) {
-      return null;
+      throw new MissingInputException(clazz);
     }
     if (!clazz.equals(datum.getClass())) {
       throw new IllegalStateException(

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
@@ -56,5 +56,6 @@ java_library(
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",
         "//third_party/guava",
+        "//third_party/jsr305",
     ],
 )

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/TotalDuration.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/TotalDuration.java
@@ -17,16 +17,18 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import java.time.Duration;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** The total duration of the invocation */
 public class TotalDuration implements Datum {
-  private final Duration totalDuration;
+  private final Optional<Duration> totalDuration;
 
-  public TotalDuration(Duration totalDuration) {
-    this.totalDuration = totalDuration;
+  public TotalDuration(@Nullable Duration totalDuration) {
+    this.totalDuration = Optional.ofNullable(totalDuration);
   }
 
-  public Duration getTotalDuration() {
+  public Optional<Duration> getTotalDuration() {
     return totalDuration;
   }
 
@@ -37,6 +39,6 @@ public class TotalDuration implements Datum {
 
   @Override
   public String getSummary() {
-    return DurationUtil.formatDuration(totalDuration);
+    return totalDuration.isEmpty() ? "n/a" : DurationUtil.formatDuration(totalDuration.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProvider.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * A {@link SuggestionProvider} that provides suggestions on how to speed up the invocation if the
@@ -96,11 +97,13 @@ public class CriticalPathNotDominantSuggestionProvider extends SuggestionProvide
 
       List<Suggestion> suggestions = new ArrayList<>();
 
-      TotalDuration totalDurationDatum = dataManager.getDatum(TotalDuration.class);
-      if (totalDurationDatum == null) {
-        throw new MissingInputException(TotalDuration.class);
+      Optional<Duration> optionalTotalDuration =
+          dataManager.getDatum(TotalDuration.class).getTotalDuration();
+      if (optionalTotalDuration.isEmpty()) {
+        return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(
+            ANALYZER_CLASSNAME, TotalDuration.class);
       }
-      Duration totalDuration = dataManager.getDatum(TotalDuration.class).getTotalDuration();
+      Duration totalDuration = optionalTotalDuration.get();
       Duration minimumDuration = totalDuration.minus(executionDuration).plus(criticalPathDuration);
       double durationReductionPercent =
           100 * (1 - minimumDuration.toMillis() / (double) totalDuration.toMillis());

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProvider.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /** A {@link SuggestionProvider} that provides suggestions regarding garbage collection. */
 public class GarbageCollectionSuggestionProvider extends SuggestionProviderBase {
@@ -47,7 +48,13 @@ public class GarbageCollectionSuggestionProvider extends SuggestionProviderBase 
       GarbageCollectionStats gcStats = dataManager.getDatum(GarbageCollectionStats.class);
 
       if (gcStats.hasMajorGarbageCollection()) {
-        Duration totalDuration = dataManager.getDatum(TotalDuration.class).getTotalDuration();
+        Optional<Duration> optionalTotalDuration =
+            dataManager.getDatum(TotalDuration.class).getTotalDuration();
+        if (optionalTotalDuration.isEmpty()) {
+          return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(
+              ANALYZER_CLASSNAME, TotalDuration.class);
+        }
+        Duration totalDuration = optionalTotalDuration.get();
         double percentOfTotal =
             100.0
                 * gcStats.getMajorGarbageCollectionDuration().toMillis()

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProvider.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A {@link SuggestionProvider} that highlights Bazel phases if they take longer than expected
@@ -56,11 +57,13 @@ public class NegligiblePhaseSuggestionProvider extends SuggestionProviderBase {
   @Override
   public SuggestionOutput getSuggestions(DataManager dataManager) {
     try {
-      TotalDuration totalDurationDatum = dataManager.getDatum(TotalDuration.class);
-      if (totalDurationDatum == null) {
-        throw new MissingInputException(TotalDuration.class);
+      Optional<Duration> optionalTotalDuration =
+          dataManager.getDatum(TotalDuration.class).getTotalDuration();
+      if (optionalTotalDuration.isEmpty()) {
+        return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(
+            ANALYZER_CLASSNAME, TotalDuration.class);
       }
-      Duration totalDuration = totalDurationDatum.getTotalDuration();
+      Duration totalDuration = optionalTotalDuration.get();
       if (totalDuration.compareTo(MIN_DURATION) < 0) {
         // Too short for this check to be valid
         Caveat caveat =

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProvider.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * A {@link SuggestionProvider} that provides suggestions on how to reduce remote execution queuing.
@@ -65,7 +66,13 @@ public class QueuingSuggestionProvider extends SuggestionProviderBase {
             && !criticalPathDuration.getCriticalPathDuration().isZero()) {
           Duration queuing = criticalPathQueuingDuration.getCriticalPathQueuingDuration();
           Duration criticalPath = criticalPathDuration.getCriticalPathDuration();
-          Duration totalDuration = dataManager.getDatum(TotalDuration.class).getTotalDuration();
+          Optional<Duration> optionalTotalDuration =
+              dataManager.getDatum(TotalDuration.class).getTotalDuration();
+          if (optionalTotalDuration.isEmpty()) {
+            return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(
+                ANALYZER_CLASSNAME, TotalDuration.class);
+          }
+          Duration totalDuration = optionalTotalDuration.get();
           double invocationDurationReductionPercentage =
               100 * queuing.toMillis() / (double) totalDuration.toMillis();
           potentialImprovement =

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
@@ -19,6 +19,7 @@ import com.engflow.bazel.invocation.analyzer.PotentialImprovement;
 import com.engflow.bazel.invocation.analyzer.Suggestion;
 import com.engflow.bazel.invocation.analyzer.SuggestionCategory;
 import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
 import com.engflow.bazel.invocation.analyzer.core.SuggestionProvider;
 import com.google.common.base.Preconditions;
@@ -179,6 +180,28 @@ public class SuggestionProviderUtil {
       builder.addAllCaveat(caveats);
     }
     return builder.build();
+  }
+
+  /**
+   * Creates a {@link SuggestionOutput} when an essential input is empty.
+   *
+   * @param analyzerClassname The name of the analyzer that produces this output.
+   * @param emptyClazz The class of the {@link Datum} that was empty.
+   * @return A {@link SuggestionOutput} with a caveat surfacing which input is empty.
+   */
+  public static SuggestionOutput createSuggestionOutputForEmptyInput(
+      String analyzerClassname, Class<? extends Datum> emptyClazz) {
+    Preconditions.checkNotNull(analyzerClassname);
+    Preconditions.checkNotNull(emptyClazz);
+    return SuggestionOutput.newBuilder()
+        .setAnalyzerClassname(analyzerClassname)
+        .addCaveat(
+            createCaveat(
+                String.format(
+                    "An essential input for determining suggestions was empty: %s",
+                    emptyClazz.getName()),
+                false))
+        .build();
   }
 
   /**

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/core/DataManagerTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/core/DataManagerTest.java
@@ -32,12 +32,12 @@ public class DataManagerTest {
 
   @Test
   public void shouldFetchRegisteredDataProvider() throws Exception {
+    Character c = (char) (new Random().nextInt(26) + 'a');
     var dataManager = new DataManager();
-    var dataProvider = new CharDataProvider();
+    var dataProvider = new CharDataProvider(c);
     dataProvider.register(dataManager);
 
-    assertThat(dataManager.getDatum(CharDatum.class).getMyChar())
-        .isEqualTo(dataProvider.returnedChar.getMyChar());
+    assertThat(dataManager.getDatum(CharDatum.class).getMyChar()).isEqualTo(c);
   }
 
   @Test
@@ -75,7 +75,7 @@ public class DataManagerTest {
   }
 
   @Test
-  public void shouldThrowMissingDataException() throws Exception {
+  public void shouldThrowMissingDataExceptionWhenInputIsMissing() throws Exception {
     var dataManager = new DataManager();
     new StringDataProvider().register(dataManager);
 
@@ -90,9 +90,37 @@ public class DataManagerTest {
   }
 
   @Test
+  public void shouldThrowMissingDataExceptionWhenNotRegistered() throws Exception {
+    var dataManager = new DataManager();
+
+    var ex =
+        assertThrows(MissingInputException.class, () -> dataManager.getDatum(StringDatum.class));
+    assertThat(ex)
+        .hasMessageThat()
+        .isEqualTo(
+            "Missing data provider for class"
+                + " \"com.engflow.bazel.invocation.analyzer.core.TestDatum$StringDatum\". Please"
+                + " register a DataProvider that supplies this type with the DataManager.");
+  }
+
+  @Test
+  public void shouldThrowMissingDataExceptionWhenSupplyingNull() throws Exception {
+    var dataManager = new DataManager();
+    new CharDataProvider(null).register(dataManager);
+
+    var ex = assertThrows(MissingInputException.class, () -> dataManager.getDatum(CharDatum.class));
+    assertThat(ex)
+        .hasMessageThat()
+        .isEqualTo(
+            "Missing data provider for class"
+                + " \"com.engflow.bazel.invocation.analyzer.core.TestDatum$CharDatum\". Please"
+                + " register a DataProvider that supplies this type with the DataManager.");
+  }
+
+  @Test
   public void shouldAllowDataProvidersToCallOneAnother() throws Exception {
     var dataManager = new DataManager();
-    CharDataProvider charDataProvider = new CharDataProvider();
+    CharDataProvider charDataProvider = new CharDataProvider('a');
     charDataProvider.register(dataManager);
     new StringDataProvider().register(dataManager);
 
@@ -105,7 +133,7 @@ public class DataManagerTest {
   @Test
   public void getAllDataByProvider() throws Exception {
     var dataManager = new DataManager();
-    var charDataProvider = new CharDataProvider();
+    var charDataProvider = new CharDataProvider('a');
     charDataProvider.register(dataManager);
     var numericDataProvider = new NumericDataProvider();
     numericDataProvider.register(dataManager);
@@ -138,7 +166,7 @@ public class DataManagerTest {
   @Test
   public void getUsedDataByProvider() throws Exception {
     var dataManager = new DataManager();
-    var charDataProvider = new CharDataProvider();
+    var charDataProvider = new CharDataProvider('a');
     charDataProvider.register(dataManager);
     var numericDataProvider = new NumericDataProvider();
     numericDataProvider.register(dataManager);
@@ -180,8 +208,8 @@ public class DataManagerTest {
   private static class CharDataProvider extends DataProvider {
     private final CharDatum returnedChar;
 
-    public CharDataProvider() {
-      this.returnedChar = new CharDatum((char) (new Random().nextInt(26) + 'a'));
+    public CharDataProvider(Character c) {
+      this.returnedChar = c == null ? null : new CharDatum(c);
     }
 
     @Override

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProviderTest.java
@@ -255,7 +255,8 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
                     FINISH_TIME))));
 
     TotalDuration duration = provider.getTotalDuration();
-    assertThat(duration.getTotalDuration())
+    assertThat(duration.getTotalDuration().isPresent()).isTrue();
+    assertThat(duration.getTotalDuration().get())
         .isEqualTo(TimeUtil.getDurationBetween(LAUNCH_START, FINISH_TIME));
   }
 
@@ -272,7 +273,8 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
                 createPhaseEvents(LAUNCH_START, null, null, null, null, null, null, FINISH_TIME))));
 
     TotalDuration duration = provider.getTotalDuration();
-    assertThat(duration.getTotalDuration())
+    assertThat(duration.getTotalDuration().isPresent()).isTrue();
+    assertThat(duration.getTotalDuration().get())
         .isEqualTo(TimeUtil.getDurationBetween(LAUNCH_START, FINISH_TIME));
   }
 

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
@@ -41,7 +41,7 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   // re-initialize the mocking).
   private BazelPhaseDescriptions.Builder phases;
   @Nullable private CriticalPathDuration criticalPathDuration;
-  @Nullable private TotalDuration totalDuration;
+  private TotalDuration totalDuration;
   private RemoteExecutionUsed remoteExecutionUsed;
   @Nullable private EstimatedCoresUsed estimatedCoresUsed;
   private EstimatedJobsFlagValue estimatedJobsFlagValue;
@@ -85,18 +85,19 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   }
 
   @Test
-  public void shouldNotReturnSuggestionIfTotalDurationIsMissing() {
+  public void shouldNotReturnSuggestionIfTotalDurationIsEmpty() {
     phases.add(
         BazelProfilePhase.EXECUTE,
         new BazelPhaseDescription(Timestamp.ofMicros(0), Timestamp.ofSeconds(100)));
-    totalDuration = null;
+    totalDuration = new TotalDuration(null);
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList()).contains(TotalDuration.class.getName());
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(TotalDuration.class.getName());
   }
 
   @Test

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProviderTest.java
@@ -15,8 +15,6 @@
 package com.engflow.bazel.invocation.analyzer.suggestionproviders;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
@@ -35,7 +33,7 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
   // are set up with reasonable defaults before each test is run, but can be overridden within the
   // tests when custom values are desired for the testing being conducted (without the need to
   // re-initialize the mocking).
-  @Nullable private TotalDuration totalDuration;
+  private TotalDuration totalDuration;
   @Nullable private BazelPhaseDescriptions.Builder bazelPhaseDescriptions;
 
   @Before
@@ -65,15 +63,16 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
   }
 
   @Test
-  public void shouldNotReturnSuggestionForMissingTotalDuration() {
-    totalDuration = null;
+  public void shouldNotReturnSuggestionForEmptyTotalDuration() {
+    totalDuration = new TotalDuration(null);
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(NegligiblePhaseSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList()).contains(TotalDuration.class.getName());
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(TotalDuration.class.getName());
   }
 
   @Test
@@ -85,8 +84,6 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
     }
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    verify(dataManager).getDatum(TotalDuration.class);
-    verifyNoMoreInteractions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(NegligiblePhaseSuggestionProvider.class.getName());
@@ -115,10 +112,6 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
 
-    verify(dataManager).getDatum(TotalDuration.class);
-    verify(dataManager).getDatum(BazelPhaseDescriptions.class);
-    verifyNoMoreInteractions(dataManager);
-
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(NegligiblePhaseSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
@@ -138,9 +131,6 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
     }
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    verify(dataManager).getDatum(TotalDuration.class);
-    verify(dataManager).getDatum(BazelPhaseDescriptions.class);
-    verifyNoMoreInteractions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(NegligiblePhaseSuggestionProvider.class.getName());
@@ -161,10 +151,6 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
     }
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-
-    verify(dataManager).getDatum(TotalDuration.class);
-    verify(dataManager).getDatum(BazelPhaseDescriptions.class);
-    verifyNoMoreInteractions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(NegligiblePhaseSuggestionProvider.class.getName());

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProviderTest.java
@@ -15,8 +15,6 @@
 package com.engflow.bazel.invocation.analyzer.suggestionproviders;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
@@ -107,12 +105,23 @@ public class QueuingSuggestionProviderTest extends SuggestionProviderUnitTestBas
   }
 
   @Test
+  public void shouldNotReturnSuggestionForEmptyTotalDuration() {
+    totalDuration = new TotalDuration(null);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(QueuingSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(TotalDuration.class.getName());
+  }
+
+  @Test
   public void shouldNotReturnSuggestionForInvocationWithoutQueuing() throws Exception {
     queuingObserved = new QueuingObserved(false);
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    verify(dataManager).getDatum(QueuingObserved.class);
-    verifyNoMoreInteractions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(QueuingSuggestionProvider.class.getName());


### PR DESCRIPTION
Progress on #38

The Bazel profile may not include all data required to extract the total duration. To handle these cases well, return an `Optional<Duration>`, where `Optional#empty` indicates the data could not be extracted.