### PR TITLE
EstimatedCoresDataProvider: use `Optional` in various `Datum`s

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProvider.java
@@ -28,6 +28,7 @@ import com.engflow.bazel.invocation.analyzer.traceeventformat.CounterEvent;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** A {@link DataProvider} that supplies data on action counts, including bottleneck statistics. */
@@ -46,11 +47,13 @@ public class ActionStatsDataProvider extends DataProvider {
       return null;
     }
 
-    var estimatedCoresUsedDatum = getDataManager().getDatum(EstimatedCoresUsed.class);
-    if (estimatedCoresUsedDatum == null) {
+    Optional<Integer> optionalEstimatedCoresUsed =
+        getDataManager().getDatum(EstimatedCoresUsed.class).getEstimatedCores();
+    if (optionalEstimatedCoresUsed.isEmpty()) {
+      // TODO: Return Optional.empty once ActionStats supports it.
       return null;
     }
-    var coresUsed = estimatedCoresUsedDatum.getEstimatedCores();
+    var coresUsed = optionalEstimatedCoresUsed.get();
 
     List<Bottleneck.Builder> bottlenecks = new ArrayList<>();
     Bottleneck.Builder currentBottleneck = null;

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCores.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCores.java
@@ -15,23 +15,31 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
+import com.google.common.base.Preconditions;
+import java.util.Optional;
 
 /** Estimate of the number of cores used or available. */
 public abstract class EstimatedCores implements Datum {
-  private final int estimatedCores;
-  private final int gaps;
+  private final Optional<Integer> estimatedCores;
+  private final Optional<Integer> gaps;
 
-  EstimatedCores(int estimatedCoresUsed, int gaps) {
-    this.estimatedCores = estimatedCoresUsed;
-    this.gaps = gaps;
+  EstimatedCores(Integer estimatedCores, Integer gaps) {
+    Preconditions.checkArgument(
+        estimatedCores != null && gaps != null || estimatedCores == null && gaps == null);
+    this.estimatedCores = Optional.ofNullable(estimatedCores);
+    this.gaps = Optional.ofNullable(gaps);
   }
 
-  public int getEstimatedCores() {
+  public boolean isEmpty() {
+    return estimatedCores.isEmpty() && gaps.isEmpty();
+  }
+
+  public Optional<Integer> getEstimatedCores() {
     return estimatedCores;
   }
 
   public boolean hasGaps() {
-    return gaps > 0;
+    return gaps.isPresent() && gaps.get() > 0;
   }
 
   /**
@@ -44,11 +52,14 @@ public abstract class EstimatedCores implements Datum {
    * Dropped evaluators with a number above the maximum found are not detected. In that, the maximum
    * found only represent a lower bound for the maximum allowed.
    */
-  public int getGaps() {
+  public Optional<Integer> getGaps() {
     return gaps;
   }
 
   public String getSummary() {
-    return String.format("%d cores (with %d gaps)", estimatedCores, gaps);
+    if (estimatedCores.isEmpty() || gaps.isEmpty()) {
+      return "n/a";
+    }
+    return String.format("%d cores (with %d gaps)", estimatedCores.get(), gaps.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresAvailable.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresAvailable.java
@@ -19,8 +19,12 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
  * flag `--jobs`. This value may both be higher or lower than {@link EstimatedCoresUsed}.
  */
 public class EstimatedCoresAvailable extends EstimatedCores {
-  public EstimatedCoresAvailable(int estimatedCoresAvailable, int gaps) {
+  public EstimatedCoresAvailable(Integer estimatedCoresAvailable, Integer gaps) {
     super(estimatedCoresAvailable, gaps);
+  }
+
+  public static EstimatedCoresAvailable empty() {
+    return new EstimatedCoresAvailable(null, null);
   }
 
   @Override

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProvider.java
@@ -66,8 +66,8 @@ public class EstimatedCoresDataProvider extends DataProvider {
     determineEstimatedCoresUsed();
     if (executionPhaseSkyframeEvaluatorsMaxValue == null
         || evaluateAndDependenciesPhaseSkyframeEvaluatorsMaxValue == null) {
-      // The Bazel profile does not include enough data to provide this Datum.
-      return null;
+      // The Bazel profile does not include the required data.
+      return EstimatedJobsFlagValue.empty();
     }
     return new EstimatedJobsFlagValue(
         executionPhaseSkyframeEvaluatorsMaxValue + 1,
@@ -81,8 +81,8 @@ public class EstimatedCoresDataProvider extends DataProvider {
     determineEstimatedCoresAvailable();
     if (evaluateAndDependenciesPhaseSkyframeEvaluators == null
         || evaluateAndDependenciesPhaseSkyframeEvaluatorsMaxValue == null) {
-      // The Bazel profile does not include enough data to provide this Datum.
-      return null;
+      // The Bazel profile does not include the required data.
+      return EstimatedCoresAvailable.empty();
     }
     return new EstimatedCoresAvailable(
         evaluateAndDependenciesPhaseSkyframeEvaluatorsMaxValue + 1,
@@ -96,8 +96,8 @@ public class EstimatedCoresDataProvider extends DataProvider {
     determineEstimatedCoresUsed();
     if (executionPhaseSkyframeEvaluators == null
         || executionPhaseSkyframeEvaluatorsMaxValue == null) {
-      // The Bazel profile does not include enough data to provide this Datum.
-      return null;
+      // The Bazel profile does not include the required data.
+      return EstimatedCoresUsed.empty();
     }
     return new EstimatedCoresUsed(
         executionPhaseSkyframeEvaluators.size(),

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresUsed.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresUsed.java
@@ -19,8 +19,12 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
  * set, this should match with {@link EstimatedCoresAvailable}.
  */
 public class EstimatedCoresUsed extends EstimatedCores {
-  public EstimatedCoresUsed(int estimatedCoresUsed, int gaps) {
+  public EstimatedCoresUsed(Integer estimatedCoresUsed, Integer gaps) {
     super(estimatedCoresUsed, gaps);
+  }
+
+  public static EstimatedCoresUsed empty() {
+    return new EstimatedCoresUsed(null, null);
   }
 
   @Override

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedJobsFlagValue.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedJobsFlagValue.java
@@ -15,6 +15,8 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
+import com.google.common.base.Preconditions;
+import java.util.Optional;
 
 /**
  * Estimated value of the Bazel flag `--jobs`. The Bazel profile includes information from which we
@@ -23,15 +25,29 @@ import com.engflow.bazel.invocation.analyzer.core.Datum;
  * cores, more likely than not the flag `--jobs` was set.
  */
 public class EstimatedJobsFlagValue implements Datum {
-  private final int lowerBound;
+  private final Optional<Integer> lowerBound;
   private final boolean likelySet;
 
-  public EstimatedJobsFlagValue(int lowerBound, boolean likelySet) {
-    this.lowerBound = lowerBound;
+  private EstimatedJobsFlagValue() {
+    this.lowerBound = Optional.empty();
+    this.likelySet = false;
+  }
+
+  public EstimatedJobsFlagValue(Integer lowerBound, boolean likelySet) {
+    Preconditions.checkNotNull(lowerBound);
+    this.lowerBound = Optional.ofNullable(lowerBound);
     this.likelySet = likelySet;
   }
 
-  public int getLowerBound() {
+  public static EstimatedJobsFlagValue empty() {
+    return new EstimatedJobsFlagValue();
+  }
+
+  public boolean isEmpty() {
+    return lowerBound.isEmpty();
+  }
+
+  public Optional<Integer> getLowerBound() {
     return lowerBound;
   }
 
@@ -47,7 +63,11 @@ public class EstimatedJobsFlagValue implements Datum {
 
   @Override
   public String getSummary() {
+    if (lowerBound.isEmpty()) {
+      return "n/a";
+    }
     return String.format(
-        "Lower bound of %d; --jobs flag is likely %s", lowerBound, likelySet ? "set" : "not set");
+        "Lower bound of %d; --jobs flag is likely %s",
+        lowerBound.get(), likelySet ? "set" : "not set");
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProvider.java
@@ -108,11 +108,13 @@ public class CriticalPathNotDominantSuggestionProvider extends SuggestionProvide
       double durationReductionPercent =
           100 * (1 - minimumDuration.toMillis() / (double) totalDuration.toMillis());
 
-      EstimatedCoresUsed estimatedCoresUsedDatum = dataManager.getDatum(EstimatedCoresUsed.class);
-      if (estimatedCoresUsedDatum == null) {
-        throw new MissingInputException(EstimatedCoresUsed.class);
+      Optional<Integer> optionalEstimatedCoresUsed =
+          dataManager.getDatum(EstimatedCoresUsed.class).getEstimatedCores();
+      if (optionalEstimatedCoresUsed.isEmpty()) {
+        return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(
+            ANALYZER_CLASSNAME, EstimatedCoresUsed.class);
       }
-      long estimatedCoresUsed = estimatedCoresUsedDatum.getEstimatedCores();
+      int estimatedCoresUsed = optionalEstimatedCoresUsed.get();
       long optimalCores =
           (long)
               Math.ceil(

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProviderTest.java
@@ -55,8 +55,9 @@ public class ActionStatsDataProviderTest extends DataProviderUnitTestBase {
   }
 
   @Test
-  public void shouldReturnNullOnMissingEstimatedCoresUsed()
+  public void shouldReturnNullOnEmptyEstimatedCoresUsed()
       throws DuplicateProviderException, MissingInputException, InvalidProfileException {
+    useEstimatedCoresUsed(null);
     useProfile(
         metaData(),
         trace(
@@ -154,9 +155,9 @@ public class ActionStatsDataProviderTest extends DataProviderUnitTestBase {
     assertThat(actionStats.bottlenecks).isEmpty();
   }
 
-  private void useEstimatedCoresUsed(int count)
+  private void useEstimatedCoresUsed(Integer count)
       throws MissingInputException, InvalidProfileException {
     when(dataManager.getDatum(EstimatedCoresUsed.class))
-        .thenReturn(new EstimatedCoresUsed(count, 0));
+        .thenReturn(new EstimatedCoresUsed(count, count == null ? null : 0));
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
@@ -71,7 +71,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     EstimatedCoresAvailable estimatedCores = provider.getEstimatedCoresAvailable();
-    assertThat(estimatedCores.getEstimatedCores()).isEqualTo(maxIndexInRelevantPhase + 1);
+    assertThat(estimatedCores.getEstimatedCores().get()).isEqualTo(maxIndexInRelevantPhase + 1);
   }
 
   @Test
@@ -98,7 +98,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     EstimatedCoresAvailable estimatedCores = provider.getEstimatedCoresAvailable();
-    assertThat(estimatedCores.getEstimatedCores()).isEqualTo(maxIndexInRelevantPhase + 1);
+    assertThat(estimatedCores.getEstimatedCores().get()).isEqualTo(maxIndexInRelevantPhase + 1);
   }
 
   @Test
@@ -121,7 +121,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
-    assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores())
+    assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores().get())
         .isEqualTo(maxIndexInRelevantPhase + 1);
   }
 
@@ -146,12 +146,12 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
-    assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores())
+    assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores().get())
         .isEqualTo(maxIndexInRelevantPhase + 1);
   }
 
   @Test
-  public void shouldNotReturnEstimatedCoresAvailablePhaseMarkersMissing() throws Exception {
+  public void shouldReturnEmptyEstimatedCoresAvailablePhaseMarkersMissing() throws Exception {
     int maxIndexInRelevantPhase = 3;
     Timestamp start = Timestamp.ofMicros(20_000);
     Timestamp within1 = Timestamp.ofMicros(22_000);
@@ -172,7 +172,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
-    assertThat(provider.getEstimatedCoresAvailable()).isNull();
+    assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores().isEmpty()).isTrue();
   }
 
   @Test
@@ -194,7 +194,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     EstimatedCoresUsed estimatedCores = provider.getEstimatedCoresUsed();
-    assertThat(estimatedCores.getEstimatedCores()).isEqualTo(4);
+    assertThat(estimatedCores.getEstimatedCores().get()).isEqualTo(4);
   }
 
   @Test
@@ -218,11 +218,12 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     EstimatedCoresUsed estimatedCores = provider.getEstimatedCoresUsed();
-    assertThat(estimatedCores.getEstimatedCores()).isEqualTo(2);
+    assertThat(estimatedCores.getEstimatedCores().get()).isEqualTo(2);
   }
 
   @Test
-  public void shouldNotReturnEstimatedCoresUsedExecutePhaseMarkerMissing() throws Exception {
+  public void shouldReturnEmptyEstimatedCoresUsedWhenExecutePhaseMarkerIsMissing()
+      throws Exception {
     Timestamp outsideRangeBefore = Timestamp.ofMicros(19_999);
     Timestamp start = Timestamp.ofMicros(20_000);
     Timestamp within1 = Timestamp.ofMicros(22_000);
@@ -244,7 +245,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
-    assertThat(provider.getEstimatedCoresUsed()).isNull();
+    assertThat(provider.getEstimatedCoresUsed().isEmpty()).isTrue();
   }
 
   @Test

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/integrationtests/JobsSuggestionProviderIntegrationTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/integrationtests/JobsSuggestionProviderIntegrationTest.java
@@ -53,17 +53,17 @@ public class JobsSuggestionProviderIntegrationTest extends IntegerationTestBase 
 
     EstimatedCoresAvailable estimatedCoresAvailable =
         dataManager.getDatum(EstimatedCoresAvailable.class);
-    assertThat(estimatedCoresAvailable.getEstimatedCores()).isEqualTo(16);
-    assertThat(estimatedCoresAvailable.getGaps()).isEqualTo(0);
+    assertThat(estimatedCoresAvailable.getEstimatedCores().get()).isEqualTo(16);
+    assertThat(estimatedCoresAvailable.getGaps().get()).isEqualTo(0);
 
     EstimatedCoresUsed estimatedCoresUsed = dataManager.getDatum(EstimatedCoresUsed.class);
-    assertThat(estimatedCoresUsed.getEstimatedCores()).isEqualTo(16);
-    assertThat(estimatedCoresUsed.getGaps()).isEqualTo(0);
+    assertThat(estimatedCoresUsed.getEstimatedCores().get()).isEqualTo(16);
+    assertThat(estimatedCoresUsed.getGaps().get()).isEqualTo(0);
 
     EstimatedJobsFlagValue estimatedJobsFlagValue =
         dataManager.getDatum(EstimatedJobsFlagValue.class);
     assertThat(estimatedJobsFlagValue.isLikelySet()).isFalse();
-    assertThat(estimatedJobsFlagValue.getLowerBound()).isEqualTo(16);
+    assertThat(estimatedJobsFlagValue.getLowerBound().get()).isEqualTo(16);
 
     SuggestionOutput output = provider.getSuggestions(dataManager);
     assertThat(output.hasFailure()).isFalse();
@@ -77,17 +77,17 @@ public class JobsSuggestionProviderIntegrationTest extends IntegerationTestBase 
 
     EstimatedCoresAvailable estimatedCoresAvailable =
         dataManager.getDatum(EstimatedCoresAvailable.class);
-    assertThat(estimatedCoresAvailable.getEstimatedCores()).isEqualTo(16);
-    assertThat(estimatedCoresAvailable.getGaps()).isEqualTo(0);
+    assertThat(estimatedCoresAvailable.getEstimatedCores().get()).isEqualTo(16);
+    assertThat(estimatedCoresAvailable.getGaps().get()).isEqualTo(0);
 
     EstimatedCoresUsed estimatedCoresUsed = dataManager.getDatum(EstimatedCoresUsed.class);
-    assertThat(estimatedCoresUsed.getEstimatedCores()).isEqualTo(4);
-    assertThat(estimatedCoresUsed.getGaps()).isEqualTo(0);
+    assertThat(estimatedCoresUsed.getEstimatedCores().get()).isEqualTo(4);
+    assertThat(estimatedCoresUsed.getGaps().get()).isEqualTo(0);
 
     EstimatedJobsFlagValue estimatedJobsFlagValue =
         dataManager.getDatum(EstimatedJobsFlagValue.class);
     assertThat(estimatedJobsFlagValue.isLikelySet()).isTrue();
-    assertThat(estimatedJobsFlagValue.getLowerBound()).isEqualTo(4);
+    assertThat(estimatedJobsFlagValue.getLowerBound().get()).isEqualTo(4);
 
     SuggestionOutput output = provider.getSuggestions(dataManager);
     assertThat(output.hasFailure()).isFalse();
@@ -102,17 +102,17 @@ public class JobsSuggestionProviderIntegrationTest extends IntegerationTestBase 
 
     EstimatedCoresAvailable estimatedCoresAvailable =
         dataManager.getDatum(EstimatedCoresAvailable.class);
-    assertThat(estimatedCoresAvailable.getEstimatedCores()).isEqualTo(16);
-    assertThat(estimatedCoresAvailable.getGaps()).isEqualTo(0);
+    assertThat(estimatedCoresAvailable.getEstimatedCores().get()).isEqualTo(16);
+    assertThat(estimatedCoresAvailable.getGaps().get()).isEqualTo(0);
 
     EstimatedCoresUsed estimatedCoresUsed = dataManager.getDatum(EstimatedCoresUsed.class);
-    assertThat(estimatedCoresUsed.getEstimatedCores()).isEqualTo(51);
-    assertThat(estimatedCoresUsed.getGaps()).isEqualTo(46);
+    assertThat(estimatedCoresUsed.getEstimatedCores().get()).isEqualTo(51);
+    assertThat(estimatedCoresUsed.getGaps().get()).isEqualTo(46);
 
     EstimatedJobsFlagValue estimatedJobsFlagValue =
         dataManager.getDatum(EstimatedJobsFlagValue.class);
     assertThat(estimatedJobsFlagValue.isLikelySet()).isTrue();
-    assertThat(estimatedJobsFlagValue.getLowerBound()).isEqualTo(97);
+    assertThat(estimatedJobsFlagValue.getLowerBound().get()).isEqualTo(97);
 
     SuggestionOutput output = provider.getSuggestions(dataManager);
     assertThat(output.hasFailure()).isFalse();

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
@@ -43,7 +43,7 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   @Nullable private CriticalPathDuration criticalPathDuration;
   private TotalDuration totalDuration;
   private RemoteExecutionUsed remoteExecutionUsed;
-  @Nullable private EstimatedCoresUsed estimatedCoresUsed;
+  private EstimatedCoresUsed estimatedCoresUsed;
   private EstimatedJobsFlagValue estimatedJobsFlagValue;
 
   @Before
@@ -101,18 +101,20 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   }
 
   @Test
-  public void shouldNotReturnSuggestionIfEstimatedCoresUsedIsMissing() {
+  public void shouldNotReturnSuggestionIfEstimatedCoresUsedIsEmpty() {
     phases.add(
         BazelProfilePhase.EXECUTE,
         new BazelPhaseDescription(Timestamp.ofMicros(0), Timestamp.ofSeconds(100)));
-    estimatedCoresUsed = null;
+    estimatedCoresUsed = new EstimatedCoresUsed(null, null);
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList()).contains(EstimatedCoresUsed.class.getName());
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(EstimatedCoresUsed.class.getName());
   }
 
   @Test

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/JobsSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/JobsSuggestionProviderTest.java
@@ -35,8 +35,10 @@ public class JobsSuggestionProviderTest extends SuggestionProviderUnitTestBase {
   }
 
   @Test
-  public void doesNotCreateSuggestionsIfEstimatedJobsFlagValueIsMissing()
+  public void doesNotCreateSuggestionsIfEstimatedJobsFlagValueIsEmpty()
       throws MissingInputException, InvalidProfileException {
+    when(dataManager.getDatum(EstimatedJobsFlagValue.class))
+        .thenReturn(EstimatedJobsFlagValue.empty());
     when(dataManager.getDatum(RemoteExecutionUsed.class))
         .thenReturn(new RemoteExecutionUsed(false));
     when(dataManager.getDatum(RemoteCachingUsed.class)).thenReturn(new RemoteCachingUsed(false));
@@ -44,7 +46,8 @@ public class JobsSuggestionProviderTest extends SuggestionProviderUnitTestBase {
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList())
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
         .contains(EstimatedJobsFlagValue.class.getName());
   }
 
@@ -77,24 +80,27 @@ public class JobsSuggestionProviderTest extends SuggestionProviderUnitTestBase {
   }
 
   @Test
-  public void doesNotCreateSuggestionsIfEstimatedCoresAvailableIsMissing()
+  public void doesNotCreateSuggestionsIfEstimatedCoresAvailableIsEmpty()
       throws MissingInputException, InvalidProfileException {
     when(dataManager.getDatum(EstimatedJobsFlagValue.class))
         .thenReturn(new EstimatedJobsFlagValue(4, true));
     when(dataManager.getDatum(RemoteExecutionUsed.class))
         .thenReturn(new RemoteExecutionUsed(false));
     when(dataManager.getDatum(RemoteCachingUsed.class)).thenReturn(new RemoteCachingUsed(false));
+    when(dataManager.getDatum(EstimatedCoresAvailable.class))
+        .thenReturn(new EstimatedCoresAvailable(null, null));
     when(dataManager.getDatum(EstimatedCoresUsed.class)).thenReturn(new EstimatedCoresUsed(4, 0));
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList())
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
         .contains(EstimatedCoresAvailable.class.getName());
   }
 
   @Test
-  public void doesNotCreateSuggestionsIfEstimatedCoresUsedIsMissing()
+  public void doesNotCreateSuggestionsIfEstimatedCoresUsedIsEmpty()
       throws MissingInputException, InvalidProfileException {
     when(dataManager.getDatum(EstimatedJobsFlagValue.class))
         .thenReturn(new EstimatedJobsFlagValue(4, true));
@@ -103,11 +109,15 @@ public class JobsSuggestionProviderTest extends SuggestionProviderUnitTestBase {
     when(dataManager.getDatum(RemoteCachingUsed.class)).thenReturn(new RemoteCachingUsed(false));
     when(dataManager.getDatum(EstimatedCoresAvailable.class))
         .thenReturn(new EstimatedCoresAvailable(2, 1));
+    when(dataManager.getDatum(EstimatedCoresUsed.class))
+        .thenReturn(new EstimatedCoresUsed(null, null));
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList()).contains(EstimatedCoresUsed.class.getName());
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(EstimatedCoresUsed.class.getName());
   }
 
   @Test


### PR DESCRIPTION
Progress on #38

The Bazel profile may not include all data required to extract the estimated cores available, estimated cores used, and value of the flag `--jobs`. To handle these cases well, return an `Optional`, where `Optional#empty` indicates the data could not be extracted.