### PR TITLE
CriticalPathDuration and CriticalPathQueuingDuration: return Optional<Duration>

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDuration.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDuration.java
@@ -17,16 +17,17 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import java.time.Duration;
+import java.util.Optional;
 
 /** The duration of the critical path */
 public class CriticalPathDuration implements Datum {
-  private final Duration criticalPathDuration;
+  private final Optional<Duration> criticalPathDuration;
 
   public CriticalPathDuration(Duration criticalPathDuration) {
-    this.criticalPathDuration = criticalPathDuration;
+    this.criticalPathDuration = Optional.ofNullable(criticalPathDuration);
   }
 
-  public Duration getCriticalPathDuration() {
+  public Optional<Duration> getCriticalPathDuration() {
     return criticalPathDuration;
   }
 
@@ -37,6 +38,9 @@ public class CriticalPathDuration implements Datum {
 
   @Override
   public String getSummary() {
-    return DurationUtil.formatDuration(criticalPathDuration);
+    if (criticalPathDuration.isEmpty()) {
+      return "n/a";
+    }
+    return DurationUtil.formatDuration(criticalPathDuration.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProvider.java
@@ -42,7 +42,7 @@ public class CriticalPathDurationDataProvider extends DataProvider {
       throws MissingInputException, InvalidProfileException {
     BazelProfile bazelProfile = getDataManager().getDatum(BazelProfile.class);
     if (bazelProfile.getCriticalPath().isEmpty()) {
-      return null;
+      return new CriticalPathDuration(null);
     }
     Duration duration =
         bazelProfile.getCriticalPath().get().getCompleteEvents().stream()

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDuration.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDuration.java
@@ -17,16 +17,17 @@ package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import java.time.Duration;
+import java.util.Optional;
 
 /** The total time spent queued on the critical path */
 public class CriticalPathQueuingDuration implements Datum {
-  private final Duration criticalPathQueuingDuration;
+  private final Optional<Duration> criticalPathQueuingDuration;
 
   public CriticalPathQueuingDuration(Duration criticalPathQueuingDuration) {
-    this.criticalPathQueuingDuration = criticalPathQueuingDuration;
+    this.criticalPathQueuingDuration = Optional.ofNullable(criticalPathQueuingDuration);
   }
 
-  public Duration getCriticalPathQueuingDuration() {
+  public Optional<Duration> getCriticalPathQueuingDuration() {
     return criticalPathQueuingDuration;
   }
 
@@ -37,6 +38,9 @@ public class CriticalPathQueuingDuration implements Datum {
 
   @Override
   public String getSummary() {
-    return DurationUtil.formatDuration(criticalPathQueuingDuration);
+    if (criticalPathQueuingDuration.isEmpty()) {
+      return "n/a";
+    }
+    return DurationUtil.formatDuration(criticalPathQueuingDuration.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
@@ -57,7 +57,7 @@ public class CriticalPathQueuingDurationDataProvider extends DataProvider {
     // within the time interval.
     Set<CompleteEvent> criticalPathEventsInThreads = new HashSet<>();
     if (bazelProfile.getCriticalPath().isEmpty()) {
-      return null;
+      return new CriticalPathQueuingDuration(null);
     }
     bazelProfile
         .getCriticalPath()

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProvider.java
@@ -70,13 +70,14 @@ public class CriticalPathNotDominantSuggestionProvider extends SuggestionProvide
             ANALYZER_CLASSNAME, null, List.of(caveat));
       }
 
-      CriticalPathDuration criticalPathDurationDatum =
-          dataManager.getDatum(CriticalPathDuration.class);
-      if (criticalPathDurationDatum == null) {
+      Optional<Duration> optionalCriticalPathDuration =
+          dataManager.getDatum(CriticalPathDuration.class).getCriticalPathDuration();
+      if (optionalCriticalPathDuration.isEmpty()) {
         // We cannot make any suggestions if we have no data about the critical path.
-        return SuggestionProviderUtil.createSuggestionOutput(ANALYZER_CLASSNAME, null, null);
+        return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(
+            ANALYZER_CLASSNAME, CriticalPathDuration.class);
       }
-      Duration criticalPathDuration = criticalPathDurationDatum.getCriticalPathDuration();
+      Duration criticalPathDuration = optionalCriticalPathDuration.get();
       if (executionDuration.compareTo(criticalPathDuration) < 0) {
         // Execution phase shorter than critical path.
         Caveat caveat =

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProviderTest.java
@@ -56,14 +56,14 @@ public class CriticalPathDurationDataProviderTest extends DataProviderUnitTestBa
                             "some action", "some category", Timestamp.ofMicros(0), duration)))));
 
     Duration totalDuration = Stream.of(durations).reduce(Duration.ZERO, Duration::plus);
-    assertThat(provider.getCriticalPathDuration().getCriticalPathDuration())
+    assertThat(provider.getCriticalPathDuration().getCriticalPathDuration().get())
         .isEqualTo(totalDuration);
   }
 
   @Test
-  public void shouldBeNullWhenCriticalPathIsMissing() throws Exception {
+  public void shouldBeEmptyWhenCriticalPathIsMissing() throws Exception {
     useProfile(metaData(), trace());
 
-    assertThat(provider.getCriticalPathDuration()).isNull();
+    assertThat(provider.getCriticalPathDuration().getCriticalPathDuration().isEmpty()).isTrue();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProviderTest.java
@@ -88,7 +88,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
         microseconds.stream()
             .map(m -> TimeUtil.getDurationForMicros(m / 10))
             .reduce(Duration.ZERO, Duration::plus);
-    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration())
+    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().get())
         .isEqualTo(totalQueueing);
   }
 
@@ -141,7 +141,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
         microseconds.stream()
             .map(m -> TimeUtil.getDurationForMicros(m / 10))
             .reduce(Duration.ZERO, Duration::plus);
-    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration())
+    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().get())
         .isEqualTo(totalQueueing);
   }
 
@@ -190,7 +190,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
                                 Timestamp.ofMicros(m),
                                 TimeUtil.getDurationForMicros(m / 10)))))));
 
-    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration())
+    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().get())
         .isEqualTo(Duration.ZERO);
   }
 
@@ -238,7 +238,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
                                 Timestamp.ofMicros(m),
                                 TimeUtil.getDurationForMicros(m + divergence)))))));
 
-    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration())
+    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().get())
         .isEqualTo(Duration.ZERO);
   }
 
@@ -284,7 +284,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
                                 Timestamp.ofMicros(m),
                                 TimeUtil.getDurationForMicros(m / 10)))))));
 
-    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration())
+    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().get())
         .isEqualTo(Duration.ZERO);
   }
 
@@ -292,14 +292,15 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
   public void shouldReturnZeroQueuingDurationWhenCriticalPathIsEmpty() throws Exception {
     useProfile(metaData(), trace(thread(0, 0, BazelProfileConstants.THREAD_CRITICAL_PATH)));
 
-    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration())
+    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().get())
         .isEqualTo(Duration.ZERO);
   }
 
   @Test
-  public void shouldBeNullWhenCriticalPathIsMissing() throws Exception {
+  public void shouldBeEmptyWhenCriticalPathIsMissing() throws Exception {
     useProfile(metaData(), trace());
 
-    assertThat(provider.getCriticalPathQueuingDuration()).isNull();
+    assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().isEmpty())
+        .isTrue();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
@@ -70,18 +70,20 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   }
 
   @Test
-  public void shouldNotReturnSuggestionIfCriticalPathDurationIsMissing() {
+  public void shouldNotReturnSuggestionIfCriticalPathDurationIsEmpty() {
     phases.add(
         BazelProfilePhase.EXECUTE,
         new BazelPhaseDescription(Timestamp.ofMicros(0), Timestamp.ofSeconds(100)));
-    criticalPathDuration = null;
+    criticalPathDuration = new CriticalPathDuration(null);
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(CriticalPathDuration.class.getName());
   }
 
   @Test

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProviderTest.java
@@ -24,7 +24,6 @@ import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.Criti
 import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.QueuingObserved;
 import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.TotalQueuingDuration;
 import java.time.Duration;
-import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,8 +34,8 @@ public class QueuingSuggestionProviderTest extends SuggestionProviderUnitTestBas
   // re-initialize the mocking).
   private TotalDuration totalDuration;
   private TotalQueuingDuration totalQueuingDuration;
-  @Nullable private CriticalPathQueuingDuration criticalPathQueuingDuration;
-  @Nullable private CriticalPathDuration criticalPathDuration;
+  private CriticalPathQueuingDuration criticalPathQueuingDuration;
+  private CriticalPathDuration criticalPathDuration;
   private QueuingObserved queuingObserved;
 
   @Before
@@ -94,8 +93,8 @@ public class QueuingSuggestionProviderTest extends SuggestionProviderUnitTestBas
   public void shouldReturnSuggestionForInvocationWithoutCriticalPath() {
     Duration totalQueuing = Duration.ofSeconds(10);
     totalQueuingDuration = new TotalQueuingDuration(totalQueuing);
-    criticalPathQueuingDuration = null;
-    criticalPathDuration = null;
+    criticalPathQueuingDuration = new CriticalPathQueuingDuration(null);
+    criticalPathDuration = new CriticalPathDuration(null);
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())


### PR DESCRIPTION
Progress on #38

The Bazel profile may not include all data required to extract the critical path durations. To handle these cases well, return an `Optional<Duration>`, where `Optional#empty` indicates the data could not be extracted.