### PR TITLE
BazelPhaseDescriptions: return `Optional<BazelPhaseDescription` on `#get`

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
@@ -20,6 +20,7 @@ import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A mapping from {@link BazelProfilePhase} to its {@link BazelPhaseDescription} in the provided
@@ -36,38 +37,38 @@ public class BazelPhaseDescriptions implements Datum {
     return new BazelPhaseDescriptions.Builder();
   }
 
-  public BazelPhaseDescription get(BazelProfilePhase phase) {
-    return phaseToDescription.get(phase);
+  public Optional<BazelPhaseDescription> get(BazelProfilePhase phase) {
+    return Optional.ofNullable(phaseToDescription.get(phase));
   }
 
   public boolean has(BazelProfilePhase phase) {
     return phaseToDescription.containsKey(phase);
   }
 
-  public BazelPhaseDescription getOrClosestBefore(BazelProfilePhase phase) {
+  public Optional<BazelPhaseDescription> getOrClosestBefore(BazelProfilePhase phase) {
     if (phaseToDescription.containsKey(phase)) {
-      return phaseToDescription.get(phase);
+      return Optional.of(phaseToDescription.get(phase));
     }
     while (phase != BazelProfilePhase.LAUNCH) {
       phase = phase.getPrevious();
       if (phaseToDescription.containsKey(phase)) {
-        return phaseToDescription.get(phase);
+        return Optional.of(phaseToDescription.get(phase));
       }
     }
-    return null;
+    return Optional.empty();
   }
 
-  public BazelPhaseDescription getOrClosestAfter(BazelProfilePhase phase) {
+  public Optional<BazelPhaseDescription> getOrClosestAfter(BazelProfilePhase phase) {
     if (phaseToDescription.containsKey(phase)) {
-      return phaseToDescription.get(phase);
+      return Optional.of(phaseToDescription.get(phase));
     }
     while (phase != BazelProfilePhase.FINISH) {
       phase = phase.getNext();
       if (phaseToDescription.containsKey(phase)) {
-        return phaseToDescription.get(phase);
+        return Optional.of(phaseToDescription.get(phase));
       }
     }
-    return null;
+    return Optional.empty();
   }
 
   @Override

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptionsTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptionsTest.java
@@ -27,7 +27,8 @@ public class BazelPhaseDescriptionsTest {
         new BazelPhaseDescription(Timestamp.ofMicros(1), Timestamp.ofMicros(2));
     BazelPhaseDescriptions descriptions =
         BazelPhaseDescriptions.newBuilder().add(BazelProfilePhase.EVALUATE, description).build();
-    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.EVALUATE)).isEqualTo(description);
+    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.EVALUATE).get())
+        .isEqualTo(description);
   }
 
   @Test
@@ -42,14 +43,14 @@ public class BazelPhaseDescriptionsTest {
             .add(BazelProfilePhase.EVALUATE, expectedDescription)
             .add(BazelProfilePhase.PREPARE, otherDescription)
             .build();
-    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.DEPENDENCIES))
+    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.DEPENDENCIES).get())
         .isEqualTo(expectedDescription);
   }
 
   @Test
-  public void getOrClosestBeforeShouldReturnNull() {
+  public void getOrClosestBeforeShouldReturnEmpty() {
     BazelPhaseDescriptions descriptions = BazelPhaseDescriptions.newBuilder().build();
-    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.EVALUATE)).isNull();
+    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.EVALUATE).isEmpty()).isTrue();
   }
 
   @Test
@@ -58,7 +59,8 @@ public class BazelPhaseDescriptionsTest {
         new BazelPhaseDescription(Timestamp.ofMicros(1), Timestamp.ofMicros(2));
     BazelPhaseDescriptions descriptions =
         BazelPhaseDescriptions.newBuilder().add(BazelProfilePhase.EVALUATE, description).build();
-    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE)).isEqualTo(description);
+    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE).get())
+        .isEqualTo(description);
   }
 
   @Test
@@ -73,13 +75,13 @@ public class BazelPhaseDescriptionsTest {
             .add(BazelProfilePhase.PREPARE, expectedDescription)
             .add(BazelProfilePhase.EXECUTE, otherDescription)
             .build();
-    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE))
+    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE).get())
         .isEqualTo(expectedDescription);
   }
 
   @Test
-  public void getOrClosestAfterShouldReturnNull() {
+  public void getOrClosestAfterShouldReturnEmpty() {
     BazelPhaseDescriptions descriptions = BazelPhaseDescriptions.newBuilder().build();
-    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE)).isNull();
+    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE).isEmpty()).isTrue();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProviderTest.java
@@ -67,31 +67,31 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
                     FINISH_TIME))));
 
     BazelPhaseDescriptions descriptions = provider.getBazelPhaseDescriptions();
-    assertThat(descriptions.get(BazelProfilePhase.LAUNCH))
+    assertThat(descriptions.get(BazelProfilePhase.LAUNCH).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 LAUNCH_START, TimeUtil.getDurationBetween(LAUNCH_START, INIT_START)));
-    assertThat(descriptions.get(BazelProfilePhase.INIT))
+    assertThat(descriptions.get(BazelProfilePhase.INIT).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 INIT_START, TimeUtil.getDurationBetween(INIT_START, EVAL_START)));
-    assertThat(descriptions.get(BazelProfilePhase.EVALUATE))
+    assertThat(descriptions.get(BazelProfilePhase.EVALUATE).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 EVAL_START, TimeUtil.getDurationBetween(EVAL_START, DEP_START)));
-    assertThat(descriptions.get(BazelProfilePhase.DEPENDENCIES))
+    assertThat(descriptions.get(BazelProfilePhase.DEPENDENCIES).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 DEP_START, TimeUtil.getDurationBetween(DEP_START, PREP_START)));
-    assertThat(descriptions.get(BazelProfilePhase.PREPARE))
+    assertThat(descriptions.get(BazelProfilePhase.PREPARE).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 PREP_START, TimeUtil.getDurationBetween(PREP_START, EXEC_START)));
-    assertThat(descriptions.get(BazelProfilePhase.EXECUTE))
+    assertThat(descriptions.get(BazelProfilePhase.EXECUTE).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 EXEC_START, TimeUtil.getDurationBetween(EXEC_START, FINISH_START)));
-    assertThat(descriptions.get(BazelProfilePhase.FINISH))
+    assertThat(descriptions.get(BazelProfilePhase.FINISH).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 FINISH_START, TimeUtil.getDurationBetween(FINISH_START, FINISH_TIME)));
@@ -117,19 +117,19 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
                     FINISH_TIME))));
 
     BazelPhaseDescriptions descriptions = provider.getBazelPhaseDescriptions();
-    assertThat(descriptions.get(BazelProfilePhase.LAUNCH))
+    assertThat(descriptions.get(BazelProfilePhase.LAUNCH).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 LAUNCH_START, TimeUtil.getDurationBetween(LAUNCH_START, INIT_START)));
-    assertThat(descriptions.get(BazelProfilePhase.INIT))
+    assertThat(descriptions.get(BazelProfilePhase.INIT).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 INIT_START, TimeUtil.getDurationBetween(INIT_START, PREP_START)));
-    assertThat(descriptions.get(BazelProfilePhase.PREPARE))
+    assertThat(descriptions.get(BazelProfilePhase.PREPARE).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 PREP_START, TimeUtil.getDurationBetween(PREP_START, FINISH_START)));
-    assertThat(descriptions.get(BazelProfilePhase.FINISH))
+    assertThat(descriptions.get(BazelProfilePhase.FINISH).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 FINISH_START, TimeUtil.getDurationBetween(FINISH_START, FINISH_TIME)));
@@ -148,7 +148,7 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
                 createPhaseEvents(LAUNCH_START, null, null, null, null, null, null, FINISH_TIME))));
 
     BazelPhaseDescriptions descriptions = provider.getBazelPhaseDescriptions();
-    assertThat(descriptions.get(BazelProfilePhase.FINISH))
+    assertThat(descriptions.get(BazelProfilePhase.FINISH).get())
         .isEqualTo(
             new BazelPhaseDescription(
                 LAUNCH_START, TimeUtil.getDurationBetween(LAUNCH_START, FINISH_TIME)));

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProviderTest.java
@@ -24,7 +24,6 @@ import com.engflow.bazel.invocation.analyzer.dataproviders.BazelPhaseDescription
 import com.engflow.bazel.invocation.analyzer.dataproviders.TotalDuration;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
-import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
   // tests when custom values are desired for the testing being conducted (without the need to
   // re-initialize the mocking).
   private TotalDuration totalDuration;
-  @Nullable private BazelPhaseDescriptions.Builder bazelPhaseDescriptions;
+  private BazelPhaseDescriptions.Builder bazelPhaseDescriptions;
 
   @Before
   public void setup() throws Exception {
@@ -47,19 +46,6 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
         .thenAnswer(i -> bazelPhaseDescriptions == null ? null : bazelPhaseDescriptions.build());
 
     suggestionProvider = new NegligiblePhaseSuggestionProvider();
-  }
-
-  @Test
-  public void shouldNotReturnSuggestionForMissingBazelPhaseDescriptions() {
-    bazelPhaseDescriptions = null;
-    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-
-    assertThat(suggestionOutput.getAnalyzerClassname())
-        .isEqualTo(NegligiblePhaseSuggestionProvider.class.getName());
-    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
-    assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList())
-        .contains(BazelPhaseDescriptions.class.getName());
   }
 
   @Test


### PR DESCRIPTION
Progress on #38

The Bazel profile may not include phase markers for all Bazel phases. To handle these cases well, return an `Optional<BazelPhaseDescription>` for a phase, where `Optional#empty` indicates the data could not be extracted.