### PR TITLE
Core: Improve messaging around empty `Datum`s

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
@@ -152,6 +152,16 @@ public class BazelProfile implements Datum {
   }
 
   @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  @Override
   public String getDescription() {
     return "The Bazel profile.";
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/core/Datum.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/core/Datum.java
@@ -16,18 +16,34 @@ package com.engflow.bazel.invocation.analyzer.core;
 
 /** Base class for all datum elements returned by {@link DataProvider}s */
 public interface Datum {
+
+  /**
+   * Check whether this datum includes any data. It may be that the input sources do not include the
+   * data required for providing information.
+   *
+   * @return Whether the datum includes no data.
+   */
+  boolean isEmpty();
+
+  /**
+   * If the datum {@link #isEmpty}, retrieve a reason explaining why it is empty.
+   *
+   * @return The reason why the datum is empty, or null if non-empty.
+   */
+  String getEmptyReason();
+
   /**
    * Get a description of the kind of data this datum provides. This description should be
    * independent of the data, i.e. static.
    *
-   * @return a description of this datum for display to the user
+   * @return A description of this datum for display to the user.
    */
   String getDescription();
 
   /**
-   * Get a summary of the actual data this datum provides.
+   * Get a summary of the actual data this datum provides. May return null if the datum is empty.
    *
-   * @return a summary of this datum for display to the user
+   * @return A summary of this datum for display to the user, or null.
    */
   String getSummary();
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStats.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStats.java
@@ -17,9 +17,11 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * This class collects all high-level aggregations of action level metrics:
@@ -29,18 +31,28 @@ import java.util.Optional;
  */
 public class ActionStats implements Datum {
   private final Optional<List<Bottleneck>> bottlenecks;
+  @Nullable private final String emptyReason;
 
-  private ActionStats() {
+  public ActionStats(String emptyReason) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(emptyReason));
     this.bottlenecks = Optional.empty();
+    this.emptyReason = emptyReason;
   }
 
   public ActionStats(List<Bottleneck> bottlenecks) {
     Preconditions.checkNotNull(bottlenecks);
     this.bottlenecks = Optional.of(bottlenecks);
+    this.emptyReason = null;
   }
 
-  public static ActionStats empty() {
-    return new ActionStats();
+  @Override
+  public boolean isEmpty() {
+    return bottlenecks.isEmpty();
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return emptyReason;
   }
 
   public Optional<List<Bottleneck>> getBottlenecks() {
@@ -55,8 +67,8 @@ public class ActionStats implements Datum {
 
   @Override
   public String getSummary() {
-    if (bottlenecks.isEmpty()) {
-      return "n/a";
+    if (isEmpty()) {
+      return null;
     }
     var duration =
         bottlenecks.get().stream().map(b -> b.getDuration()).reduce(Duration.ZERO, Duration::plus);

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProvider.java
@@ -33,6 +33,15 @@ import java.util.stream.Collectors;
 
 /** A {@link DataProvider} that supplies data on action counts, including bottleneck statistics. */
 public class ActionStatsDataProvider extends DataProvider {
+  public static final String EMPTY_REASON_ACTION_COUNT =
+      "The Bazel profile does not include an action count, which is required for extracting"
+          + " bottlenecks. Try analyzing a profile that processes actions, for example a build or"
+          + " test.";
+  public static final String EMPTY_REASON_ESTIMATED_CORES_USED =
+      "The Bazel profile does not include the data required for estimating the number of cores"
+          + " used, which is needed for extracting bottlenecks. Try analyzing a profile that"
+          + " processes actions, for example a build or test.";
+
   @Override
   public List<DatumSupplierSpecification<?>> getSuppliers() {
     return List.of(
@@ -44,13 +53,13 @@ public class ActionStatsDataProvider extends DataProvider {
     var actionCounts =
         bazelProfile.getMainThread().getCounts().get(BazelProfileConstants.COUNTER_ACTION_COUNT);
     if (actionCounts == null) {
-      return ActionStats.empty();
+      return new ActionStats(EMPTY_REASON_ACTION_COUNT);
     }
 
     Optional<Integer> optionalEstimatedCoresUsed =
         getDataManager().getDatum(EstimatedCoresUsed.class).getEstimatedCores();
     if (optionalEstimatedCoresUsed.isEmpty()) {
-      return ActionStats.empty();
+      return new ActionStats(EMPTY_REASON_ESTIMATED_CORES_USED);
     }
     var coresUsed = optionalEstimatedCoresUsed.get();
 

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptions.java
@@ -72,6 +72,16 @@ public class BazelPhaseDescriptions implements Datum {
   }
 
   @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  @Override
   public String getDescription() {
     return "The Bazel Profile's various phases and their timing information.";
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProvider.java
@@ -42,6 +42,14 @@ import java.util.logging.Logger;
  * </ul>
  */
 public class BazelPhasesDataProvider extends DataProvider {
+  private static final String TOTAL_DURATION_EMPTY_REASON_LAUNCH =
+      "The Bazel profile does not include a launch marker, which is required for determining the"
+          + " invocation's total duration. All Bazel profiles should include this data. Try"
+          + " creating a new profile.";
+  private static final String TOTAL_DURATION_EMPTY_REASON_COMPLETE =
+      "The Bazel profile does not include a completion marker, which is required for determining"
+          + " the invocation's total duration. All Bazel profiles should include this data. Try"
+          + " creating a new profile.";
   private static final Logger logger = Logger.getLogger(BazelProfile.class.getName());
 
   private Timestamp launchStart;
@@ -102,6 +110,12 @@ public class BazelPhasesDataProvider extends DataProvider {
   @VisibleForTesting
   TotalDuration getTotalDuration() throws MissingInputException, InvalidProfileException {
     determineStartAndEndTimestamps();
+    if (launchStart == null) {
+      return new TotalDuration(TOTAL_DURATION_EMPTY_REASON_LAUNCH);
+    }
+    if (finishEnd == null) {
+      return new TotalDuration(TOTAL_DURATION_EMPTY_REASON_COMPLETE);
+    }
     return new TotalDuration(TimeUtil.getDurationBetween(launchStart, finishEnd));
   }
 

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDuration.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDuration.java
@@ -16,19 +16,41 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.time.Duration;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** The duration of the critical path */
 public class CriticalPathDuration implements Datum {
   private final Optional<Duration> criticalPathDuration;
+  @Nullable private final String emptyReason;
+
+  public CriticalPathDuration(String emptyReason) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(emptyReason));
+    this.criticalPathDuration = Optional.empty();
+    this.emptyReason = emptyReason;
+  }
 
   public CriticalPathDuration(Duration criticalPathDuration) {
-    this.criticalPathDuration = Optional.ofNullable(criticalPathDuration);
+    Preconditions.checkNotNull(criticalPathDuration);
+    this.criticalPathDuration = Optional.of(criticalPathDuration);
+    this.emptyReason = null;
   }
 
   public Optional<Duration> getCriticalPathDuration() {
     return criticalPathDuration;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return criticalPathDuration.isEmpty();
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return emptyReason;
   }
 
   @Override
@@ -38,9 +60,6 @@ public class CriticalPathDuration implements Datum {
 
   @Override
   public String getSummary() {
-    if (criticalPathDuration.isEmpty()) {
-      return "n/a";
-    }
-    return DurationUtil.formatDuration(criticalPathDuration.get());
+    return isEmpty() ? null : DurationUtil.formatDuration(criticalPathDuration.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProvider.java
@@ -29,6 +29,10 @@ import java.util.List;
  * of the durations of all actions that are part of the critical path is calculated.
  */
 public class CriticalPathDurationDataProvider extends DataProvider {
+  public static final String EMPTY_REASON =
+      "The Bazel profile does not include a critical path, which is required for determining its"
+          + " duration. Try analyzing a profile that processes actions, for example a build or"
+          + " test.";
 
   @Override
   public List<DatumSupplierSpecification<?>> getSuppliers() {
@@ -42,7 +46,7 @@ public class CriticalPathDurationDataProvider extends DataProvider {
       throws MissingInputException, InvalidProfileException {
     BazelProfile bazelProfile = getDataManager().getDatum(BazelProfile.class);
     if (bazelProfile.getCriticalPath().isEmpty()) {
-      return new CriticalPathDuration(null);
+      return new CriticalPathDuration(EMPTY_REASON);
     }
     Duration duration =
         bazelProfile.getCriticalPath().get().getCompleteEvents().stream()

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCores.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCores.java
@@ -16,22 +16,39 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** Estimate of the number of cores used or available. */
 public abstract class EstimatedCores implements Datum {
   private final Optional<Integer> estimatedCores;
   private final Optional<Integer> gaps;
+  @Nullable private final String emptyReason;
 
   EstimatedCores(Integer estimatedCores, Integer gaps) {
-    Preconditions.checkArgument(
-        estimatedCores != null && gaps != null || estimatedCores == null && gaps == null);
-    this.estimatedCores = Optional.ofNullable(estimatedCores);
-    this.gaps = Optional.ofNullable(gaps);
+    Preconditions.checkNotNull(estimatedCores);
+    Preconditions.checkNotNull(gaps);
+    this.estimatedCores = Optional.of(estimatedCores);
+    this.gaps = Optional.of(gaps);
+    this.emptyReason = null;
   }
 
+  EstimatedCores(String emptyReason) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(emptyReason));
+    this.estimatedCores = Optional.empty();
+    this.gaps = Optional.empty();
+    this.emptyReason = emptyReason;
+  }
+
+  @Override
   public boolean isEmpty() {
     return estimatedCores.isEmpty() && gaps.isEmpty();
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return emptyReason;
   }
 
   public Optional<Integer> getEstimatedCores() {
@@ -57,9 +74,8 @@ public abstract class EstimatedCores implements Datum {
   }
 
   public String getSummary() {
-    if (estimatedCores.isEmpty() || gaps.isEmpty()) {
-      return "n/a";
-    }
-    return String.format("%d cores (with %d gaps)", estimatedCores.get(), gaps.get());
+    return isEmpty()
+        ? null
+        : String.format("%d cores (with %d gaps)", estimatedCores.get(), gaps.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresAvailable.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresAvailable.java
@@ -19,12 +19,12 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
  * flag `--jobs`. This value may both be higher or lower than {@link EstimatedCoresUsed}.
  */
 public class EstimatedCoresAvailable extends EstimatedCores {
-  public EstimatedCoresAvailable(Integer estimatedCoresAvailable, Integer gaps) {
-    super(estimatedCoresAvailable, gaps);
+  public EstimatedCoresAvailable(String emptyReason) {
+    super(emptyReason);
   }
 
-  public static EstimatedCoresAvailable empty() {
-    return new EstimatedCoresAvailable(null, null);
+  public EstimatedCoresAvailable(Integer estimatedCoresAvailable, Integer gaps) {
+    super(estimatedCoresAvailable, gaps);
   }
 
   @Override

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresUsed.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresUsed.java
@@ -19,12 +19,12 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
  * set, this should match with {@link EstimatedCoresAvailable}.
  */
 public class EstimatedCoresUsed extends EstimatedCores {
-  public EstimatedCoresUsed(Integer estimatedCoresUsed, Integer gaps) {
-    super(estimatedCoresUsed, gaps);
+  public EstimatedCoresUsed(String emptyReason) {
+    super(emptyReason);
   }
 
-  public static EstimatedCoresUsed empty() {
-    return new EstimatedCoresUsed(null, null);
+  public EstimatedCoresUsed(Integer estimatedCoresUsed, Integer gaps) {
+    super(estimatedCoresUsed, gaps);
   }
 
   @Override

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedJobsFlagValue.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedJobsFlagValue.java
@@ -16,7 +16,9 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Estimated value of the Bazel flag `--jobs`. The Bazel profile includes information from which we
@@ -27,24 +29,20 @@ import java.util.Optional;
 public class EstimatedJobsFlagValue implements Datum {
   private final Optional<Integer> lowerBound;
   private final boolean likelySet;
+  @Nullable private final String emptyReason;
 
-  private EstimatedJobsFlagValue() {
+  public EstimatedJobsFlagValue(String emptyReason) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(emptyReason));
     this.lowerBound = Optional.empty();
     this.likelySet = false;
+    this.emptyReason = emptyReason;
   }
 
   public EstimatedJobsFlagValue(Integer lowerBound, boolean likelySet) {
     Preconditions.checkNotNull(lowerBound);
     this.lowerBound = Optional.ofNullable(lowerBound);
     this.likelySet = likelySet;
-  }
-
-  public static EstimatedJobsFlagValue empty() {
-    return new EstimatedJobsFlagValue();
-  }
-
-  public boolean isEmpty() {
-    return lowerBound.isEmpty();
+    this.emptyReason = null;
   }
 
   public Optional<Integer> getLowerBound() {
@@ -56,6 +54,16 @@ public class EstimatedJobsFlagValue implements Datum {
   }
 
   @Override
+  public boolean isEmpty() {
+    return lowerBound.isEmpty();
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return emptyReason;
+  }
+
+  @Override
   public String getDescription() {
     return "Based on the Bazel profile, the estimated value that the Bazel flag `--jobs` was set"
         + " to.";
@@ -63,11 +71,10 @@ public class EstimatedJobsFlagValue implements Datum {
 
   @Override
   public String getSummary() {
-    if (lowerBound.isEmpty()) {
-      return "n/a";
-    }
-    return String.format(
-        "Lower bound of %d; --jobs flag is likely %s",
-        lowerBound.get(), likelySet ? "set" : "not set");
+    return isEmpty()
+        ? null
+        : String.format(
+            "Lower bound of %d; --jobs flag is likely %s",
+            lowerBound.get(), likelySet ? "set" : "not set");
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStats.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStats.java
@@ -40,6 +40,16 @@ public class GarbageCollectionStats implements Datum {
   }
 
   @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  @Override
   public String getDescription() {
     return "The total duration of major garbage collection as extracted from the Bazel profile.";
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/MergedEventsPresent.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/MergedEventsPresent.java
@@ -29,6 +29,16 @@ public class MergedEventsPresent implements Datum {
   }
 
   @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  @Override
   public String getDescription() {
     return "Whether the Bazel profile includes merged events.";
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/TotalDuration.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/TotalDuration.java
@@ -16,20 +16,40 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.time.Duration;
 import java.util.Optional;
-import javax.annotation.Nullable;
 
 /** The total duration of the invocation */
 public class TotalDuration implements Datum {
   private final Optional<Duration> totalDuration;
+  private final String emptyReason;
 
-  public TotalDuration(@Nullable Duration totalDuration) {
-    this.totalDuration = Optional.ofNullable(totalDuration);
+  public TotalDuration(String emptyReason) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(emptyReason));
+    this.totalDuration = Optional.empty();
+    this.emptyReason = emptyReason;
+  }
+
+  public TotalDuration(Duration totalDuration) {
+    Preconditions.checkNotNull(totalDuration);
+    this.totalDuration = Optional.of(totalDuration);
+    this.emptyReason = null;
   }
 
   public Optional<Duration> getTotalDuration() {
     return totalDuration;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return totalDuration.isEmpty();
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return emptyReason;
   }
 
   @Override
@@ -39,6 +59,6 @@ public class TotalDuration implements Datum {
 
   @Override
   public String getSummary() {
-    return totalDuration.isEmpty() ? "n/a" : DurationUtil.formatDuration(totalDuration.get());
+    return isEmpty() ? null : DurationUtil.formatDuration(totalDuration.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
@@ -30,5 +30,7 @@ java_library(
     deps = [
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/core",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
+        "@guava//jar",
+        "@jsr305//jar",
     ],
 )

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDuration.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDuration.java
@@ -16,19 +16,41 @@ package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.time.Duration;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** The total time spent queued on the critical path */
 public class CriticalPathQueuingDuration implements Datum {
   private final Optional<Duration> criticalPathQueuingDuration;
+  @Nullable private final String emptyReason;
+
+  public CriticalPathQueuingDuration(String emptyReason) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(emptyReason));
+    this.criticalPathQueuingDuration = Optional.empty();
+    this.emptyReason = emptyReason;
+  }
 
   public CriticalPathQueuingDuration(Duration criticalPathQueuingDuration) {
-    this.criticalPathQueuingDuration = Optional.ofNullable(criticalPathQueuingDuration);
+    Preconditions.checkNotNull(criticalPathQueuingDuration);
+    this.criticalPathQueuingDuration = Optional.of(criticalPathQueuingDuration);
+    this.emptyReason = null;
   }
 
   public Optional<Duration> getCriticalPathQueuingDuration() {
     return criticalPathQueuingDuration;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return criticalPathQueuingDuration.isEmpty();
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return emptyReason;
   }
 
   @Override
@@ -38,9 +60,6 @@ public class CriticalPathQueuingDuration implements Datum {
 
   @Override
   public String getSummary() {
-    if (criticalPathQueuingDuration.isEmpty()) {
-      return "n/a";
-    }
-    return DurationUtil.formatDuration(criticalPathQueuingDuration.get());
+    return isEmpty() ? null : DurationUtil.formatDuration(criticalPathQueuingDuration.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
@@ -38,6 +38,10 @@ import java.util.regex.Pattern;
  */
 public class CriticalPathQueuingDurationDataProvider extends DataProvider {
   private static final Pattern CRITICAL_PATH_TO_EVENT_NAME = Pattern.compile("^action '(.*)'$");
+  public static final String EMPTY_REASON =
+      "The Bazel profile does not include a critical path, which is required for determining"
+          + " whether it has queuing. Try analyzing a profile that processes actions, for example a"
+          + " build or test.";
 
   @Override
   public List<DatumSupplierSpecification<?>> getSuppliers() {
@@ -57,7 +61,7 @@ public class CriticalPathQueuingDurationDataProvider extends DataProvider {
     // within the time interval.
     Set<CompleteEvent> criticalPathEventsInThreads = new HashSet<>();
     if (bazelProfile.getCriticalPath().isEmpty()) {
-      return new CriticalPathQueuingDuration(null);
+      return new CriticalPathQueuingDuration(EMPTY_REASON);
     }
     bazelProfile
         .getCriticalPath()

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/QueuingObserved.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/QueuingObserved.java
@@ -29,6 +29,16 @@ public class QueuingObserved implements Datum {
   }
 
   @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  @Override
   public String getDescription() {
     return "Whether the Bazel profile includes queuing.";
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteCachingUsed.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteCachingUsed.java
@@ -29,6 +29,16 @@ public class RemoteCachingUsed implements Datum {
   }
 
   @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  @Override
   public String getDescription() {
     return "Whether the Bazel Profile includes events indicating that remote caching was used.";
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsed.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsed.java
@@ -29,6 +29,16 @@ public class RemoteExecutionUsed implements Datum {
   }
 
   @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  @Override
   public String getDescription() {
     return "Whether the Bazel Profile includes events indicating that remote execution was used.";
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/TotalQueuingDuration.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/TotalQueuingDuration.java
@@ -16,6 +16,7 @@ package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
+import com.google.common.base.Preconditions;
 import java.time.Duration;
 
 /** Total time actions spent queued */
@@ -23,11 +24,22 @@ public class TotalQueuingDuration implements Datum {
   private final Duration totalQueuingDuration;
 
   public TotalQueuingDuration(Duration totalQueuingDuration) {
+    Preconditions.checkNotNull(totalQueuingDuration);
     this.totalQueuingDuration = totalQueuingDuration;
   }
 
   public Duration getTotalQueuingDuration() {
     return totalQueuingDuration;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
   }
 
   @Override

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProvider.java
@@ -42,6 +42,11 @@ import java.util.Optional;
 public class NegligiblePhaseSuggestionProvider extends SuggestionProviderBase {
   private static final String ANALYZER_CLASSNAME =
       NegligiblePhaseSuggestionProvider.class.getName();
+
+  @VisibleForTesting
+  static final String EMPTY_REASON_PREFIX =
+      "No phases could be checked for an unusual relative duration. ";
+
   private static final String SUGGESTION_ID_UNUSUAL_PHASE_DURATION_FORMAT =
       "UnusualPhaseDuration-%s";
 
@@ -58,13 +63,12 @@ public class NegligiblePhaseSuggestionProvider extends SuggestionProviderBase {
   @Override
   public SuggestionOutput getSuggestions(DataManager dataManager) {
     try {
-      Optional<Duration> optionalTotalDuration =
-          dataManager.getDatum(TotalDuration.class).getTotalDuration();
-      if (optionalTotalDuration.isEmpty()) {
+      TotalDuration totalDurationDatum = dataManager.getDatum(TotalDuration.class);
+      if (totalDurationDatum.isEmpty()) {
         return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(
-            ANALYZER_CLASSNAME, TotalDuration.class);
+            ANALYZER_CLASSNAME, EMPTY_REASON_PREFIX + totalDurationDatum.getEmptyReason());
       }
-      Duration totalDuration = optionalTotalDuration.get();
+      Duration totalDuration = totalDurationDatum.getTotalDuration().get();
       if (totalDuration.compareTo(MIN_DURATION) < 0) {
         // Too short for this check to be valid
         Caveat caveat =

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
@@ -183,7 +183,9 @@ public class SuggestionProviderUtil {
   }
 
   /**
-   * Creates a {@link SuggestionOutput} when an essential input is empty.
+   * Creates a basic {@link SuggestionOutput} when an essential input is empty. Prefer using {@link
+   * #createSuggestionOutputForEmptyInput(String, String)} and provide a meaningful message
+   * explaining why the empty input prevents further analysis.
    *
    * @param analyzerClassname The name of the analyzer that produces this output.
    * @param emptyClazz The class of the {@link Datum} that was empty.
@@ -199,8 +201,17 @@ public class SuggestionProviderUtil {
             createCaveat(
                 String.format(
                     "An essential input for determining suggestions was empty: %s",
-                    emptyClazz.getName()),
+                    emptyClazz.getSimpleName()),
                 false))
+        .build();
+  }
+
+  public static SuggestionOutput createSuggestionOutputForEmptyInput(
+      String analyzerClassname, String reason) {
+    Preconditions.checkNotNull(analyzerClassname);
+    return SuggestionOutput.newBuilder()
+        .setAnalyzerClassname(analyzerClassname)
+        .addCaveat(createCaveat(reason, false))
         .build();
   }
 

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/core/TestDatum.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/core/TestDatum.java
@@ -28,6 +28,16 @@ public class TestDatum {
     }
 
     @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public String getEmptyReason() {
+      return null;
+    }
+
+    @Override
     public String getDescription() {
       return "An integer.";
     }
@@ -47,6 +57,16 @@ public class TestDatum {
 
     public double getMyDouble() {
       return myDouble;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public String getEmptyReason() {
+      return null;
     }
 
     @Override
@@ -72,6 +92,16 @@ public class TestDatum {
     }
 
     @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public String getEmptyReason() {
+      return null;
+    }
+
+    @Override
     public String getDescription() {
       return "A char.";
     }
@@ -91,6 +121,16 @@ public class TestDatum {
 
     public String getMyString() {
       return myString;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return myString == null;
+    }
+
+    @Override
+    public String getEmptyReason() {
+      return isEmpty() ? "because" : null;
     }
 
     @Override

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProviderTest.java
@@ -158,6 +158,7 @@ public class ActionStatsDataProviderTest extends DataProviderUnitTestBase {
   private void useEstimatedCoresUsed(Integer count)
       throws MissingInputException, InvalidProfileException {
     when(dataManager.getDatum(EstimatedCoresUsed.class))
-        .thenReturn(new EstimatedCoresUsed(count, count == null ? null : 0));
+        .thenReturn(
+            count == null ? new EstimatedCoresUsed("empty") : new EstimatedCoresUsed(count, 0));
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProviderTest.java
@@ -42,7 +42,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
   @Test
   public void doesNotCreateSuggestionsIfActionStatsIsEmpty()
       throws MissingInputException, InvalidProfileException {
-    when(dataManager.getDatum(ActionStats.class)).thenReturn(ActionStats.empty());
+    when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats("empty"));
     when(dataManager.getDatum(EstimatedCoresUsed.class)).thenReturn(new EstimatedCoresUsed(4, 0));
     when(dataManager.getDatum(TotalDuration.class))
         .thenReturn(new TotalDuration(Duration.ofSeconds(100)));
@@ -53,7 +53,9 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
     assertThat(suggestions.getCaveatList()).hasSize(1);
-    assertThat(suggestions.getCaveat(0).getMessage()).contains(ActionStats.class.getName());
+    assertThat(suggestions.getCaveat(0).getMessage())
+        .contains(BottleneckSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestions.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test
@@ -61,7 +63,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
       throws MissingInputException, InvalidProfileException {
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of()));
     when(dataManager.getDatum(EstimatedCoresUsed.class))
-        .thenReturn(new EstimatedCoresUsed(null, null));
+        .thenReturn(new EstimatedCoresUsed("empty"));
     when(dataManager.getDatum(TotalDuration.class))
         .thenReturn(new TotalDuration(Duration.ofSeconds(100)));
 
@@ -71,7 +73,9 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
     assertThat(suggestions.getCaveatList()).hasSize(1);
-    assertThat(suggestions.getCaveat(0).getMessage()).contains(EstimatedCoresUsed.class.getName());
+    assertThat(suggestions.getCaveat(0).getMessage())
+        .contains(BottleneckSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestions.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test
@@ -79,7 +83,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
       throws MissingInputException, InvalidProfileException {
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of()));
     when(dataManager.getDatum(EstimatedCoresUsed.class)).thenReturn(new EstimatedCoresUsed(4, 0));
-    when(dataManager.getDatum(TotalDuration.class)).thenReturn(new TotalDuration(null));
+    when(dataManager.getDatum(TotalDuration.class)).thenReturn(new TotalDuration("empty"));
 
     final var bottleneckSuggestionProvider =
         new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
@@ -87,7 +91,9 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
     assertThat(suggestions.getCaveatList()).hasSize(1);
-    assertThat(suggestions.getCaveat(0).getMessage()).contains(TotalDuration.class.getName());
+    assertThat(suggestions.getCaveat(0).getMessage())
+        .contains(BottleneckSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestions.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/CriticalPathNotDominantSuggestionProviderTest.java
@@ -30,7 +30,6 @@ import com.engflow.bazel.invocation.analyzer.dataproviders.TotalDuration;
 import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteExecutionUsed;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
-import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +39,7 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
   // tests when custom values are desired for the testing being conducted (without the need to
   // re-initialize the mocking).
   private BazelPhaseDescriptions.Builder phases;
-  @Nullable private CriticalPathDuration criticalPathDuration;
+  private CriticalPathDuration criticalPathDuration;
   private TotalDuration totalDuration;
   private RemoteExecutionUsed remoteExecutionUsed;
   private EstimatedCoresUsed estimatedCoresUsed;
@@ -74,16 +73,18 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
     phases.add(
         BazelProfilePhase.EXECUTE,
         new BazelPhaseDescription(Timestamp.ofMicros(0), Timestamp.ofSeconds(100)));
-    criticalPathDuration = new CriticalPathDuration(null);
+    criticalPathDuration = new CriticalPathDuration("empty");
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
     assertThat(suggestionOutput.getCaveat(0).getMessage())
-        .contains(CriticalPathDuration.class.getName());
+        .contains(CriticalPathNotDominantSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test
@@ -91,15 +92,18 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
     phases.add(
         BazelProfilePhase.EXECUTE,
         new BazelPhaseDescription(Timestamp.ofMicros(0), Timestamp.ofSeconds(100)));
-    totalDuration = new TotalDuration(null);
+    totalDuration = new TotalDuration("empty");
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
-    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(TotalDuration.class.getName());
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(CriticalPathNotDominantSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test
@@ -107,16 +111,18 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
     phases.add(
         BazelProfilePhase.EXECUTE,
         new BazelPhaseDescription(Timestamp.ofMicros(0), Timestamp.ofSeconds(100)));
-    estimatedCoresUsed = new EstimatedCoresUsed(null, null);
+    estimatedCoresUsed = new EstimatedCoresUsed("empty");
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
     assertThat(suggestionOutput.getCaveat(0).getMessage())
-        .contains(EstimatedCoresUsed.class.getName());
+        .contains(CriticalPathNotDominantSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test
@@ -127,6 +133,10 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(CriticalPathNotDominantSuggestionProvider.EMPTY_REASON_PREFIX);
   }
 
   @Test
@@ -141,6 +151,8 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
         .isEqualTo(CriticalPathNotDominantSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
   }
 
   @Test
@@ -157,6 +169,8 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
 
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
+    assertThat(suggestionOutput.getCaveatList()).isEmpty();
   }
 
   @Test
@@ -177,6 +191,8 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
     assertThat(suggestionOutput.getSuggestionList().get(0).getRecommendation())
         .contains("more cores");
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
+    assertThat(suggestionOutput.getCaveatList()).isEmpty();
   }
 
   @Test
@@ -197,5 +213,7 @@ public class CriticalPathNotDominantSuggestionProviderTest extends SuggestionPro
     assertThat(suggestionOutput.getSuggestionList().size()).isEqualTo(1);
     assertThat(suggestionOutput.getSuggestionList().get(0).getRecommendation()).contains("--jobs");
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
+    assertThat(suggestionOutput.getCaveatList()).isEmpty();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProviderTest.java
@@ -69,7 +69,7 @@ public class GarbageCollectionSuggestionProviderTest extends SuggestionProviderU
 
   @Test
   public void shouldNotReturnSuggestionForEmptyTotalDuration() {
-    totalDuration = new TotalDuration(null);
+    totalDuration = new TotalDuration("empty");
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
 
@@ -78,7 +78,9 @@ public class GarbageCollectionSuggestionProviderTest extends SuggestionProviderU
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
-    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(TotalDuration.class.getName());
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(GarbageCollectionSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/JobsSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/JobsSuggestionProviderTest.java
@@ -38,7 +38,7 @@ public class JobsSuggestionProviderTest extends SuggestionProviderUnitTestBase {
   public void doesNotCreateSuggestionsIfEstimatedJobsFlagValueIsEmpty()
       throws MissingInputException, InvalidProfileException {
     when(dataManager.getDatum(EstimatedJobsFlagValue.class))
-        .thenReturn(EstimatedJobsFlagValue.empty());
+        .thenReturn(new EstimatedJobsFlagValue("empty"));
     when(dataManager.getDatum(RemoteExecutionUsed.class))
         .thenReturn(new RemoteExecutionUsed(false));
     when(dataManager.getDatum(RemoteCachingUsed.class)).thenReturn(new RemoteCachingUsed(false));
@@ -46,37 +46,11 @@ public class JobsSuggestionProviderTest extends SuggestionProviderUnitTestBase {
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
     assertThat(suggestionOutput.getCaveat(0).getMessage())
-        .contains(EstimatedJobsFlagValue.class.getName());
-  }
-
-  @Test
-  public void doesNotCreateSuggestionsIfRemoteExecutionUsedIsMissing()
-      throws MissingInputException, InvalidProfileException {
-    when(dataManager.getDatum(EstimatedJobsFlagValue.class))
-        .thenReturn(new EstimatedJobsFlagValue(4, false));
-    when(dataManager.getDatum(RemoteCachingUsed.class)).thenReturn(new RemoteCachingUsed(false));
-
-    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
-    assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList())
-        .contains(RemoteExecutionUsed.class.getName());
-  }
-
-  @Test
-  public void doesNotCreateSuggestionsIfRemoteCachingUsedIsMissing()
-      throws MissingInputException, InvalidProfileException {
-    when(dataManager.getDatum(EstimatedJobsFlagValue.class))
-        .thenReturn(new EstimatedJobsFlagValue(4, false));
-    when(dataManager.getDatum(RemoteExecutionUsed.class))
-        .thenReturn(new RemoteExecutionUsed(false));
-
-    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
-    assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList()).contains(RemoteCachingUsed.class.getName());
+        .contains(JobsSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test
@@ -88,15 +62,17 @@ public class JobsSuggestionProviderTest extends SuggestionProviderUnitTestBase {
         .thenReturn(new RemoteExecutionUsed(false));
     when(dataManager.getDatum(RemoteCachingUsed.class)).thenReturn(new RemoteCachingUsed(false));
     when(dataManager.getDatum(EstimatedCoresAvailable.class))
-        .thenReturn(new EstimatedCoresAvailable(null, null));
+        .thenReturn(new EstimatedCoresAvailable("empty"));
     when(dataManager.getDatum(EstimatedCoresUsed.class)).thenReturn(new EstimatedCoresUsed(4, 0));
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
     assertThat(suggestionOutput.getCaveat(0).getMessage())
-        .contains(EstimatedCoresAvailable.class.getName());
+        .contains(JobsSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test
@@ -110,14 +86,16 @@ public class JobsSuggestionProviderTest extends SuggestionProviderUnitTestBase {
     when(dataManager.getDatum(EstimatedCoresAvailable.class))
         .thenReturn(new EstimatedCoresAvailable(2, 1));
     when(dataManager.getDatum(EstimatedCoresUsed.class))
-        .thenReturn(new EstimatedCoresUsed(null, null));
+        .thenReturn(new EstimatedCoresUsed("empty"));
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
     assertThat(suggestionOutput.getCaveat(0).getMessage())
-        .contains(EstimatedCoresUsed.class.getName());
+        .contains(JobsSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProviderTest.java
@@ -43,14 +43,14 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
     when(dataManager.getDatum(TotalDuration.class)).thenAnswer(i -> totalDuration);
     bazelPhaseDescriptions = BazelPhaseDescriptions.newBuilder();
     when(dataManager.getDatum(BazelPhaseDescriptions.class))
-        .thenAnswer(i -> bazelPhaseDescriptions == null ? null : bazelPhaseDescriptions.build());
+        .thenAnswer(i -> bazelPhaseDescriptions.build());
 
     suggestionProvider = new NegligiblePhaseSuggestionProvider();
   }
 
   @Test
   public void shouldNotReturnSuggestionForEmptyTotalDuration() {
-    totalDuration = new TotalDuration(null);
+    totalDuration = new TotalDuration("empty");
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
 
     assertThat(suggestionOutput.getAnalyzerClassname())
@@ -58,7 +58,9 @@ public class NegligiblePhaseSuggestionProviderTest extends SuggestionProviderUni
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
-    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(TotalDuration.class.getName());
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(NegligiblePhaseSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProviderTest.java
@@ -93,8 +93,8 @@ public class QueuingSuggestionProviderTest extends SuggestionProviderUnitTestBas
   public void shouldReturnSuggestionForInvocationWithoutCriticalPath() {
     Duration totalQueuing = Duration.ofSeconds(10);
     totalQueuingDuration = new TotalQueuingDuration(totalQueuing);
-    criticalPathQueuingDuration = new CriticalPathQueuingDuration(null);
-    criticalPathDuration = new CriticalPathDuration(null);
+    criticalPathQueuingDuration = new CriticalPathQueuingDuration("empty");
+    criticalPathDuration = new CriticalPathDuration("empty");
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())
@@ -105,15 +105,18 @@ public class QueuingSuggestionProviderTest extends SuggestionProviderUnitTestBas
 
   @Test
   public void shouldNotReturnSuggestionForEmptyTotalDuration() {
-    totalDuration = new TotalDuration(null);
+    totalDuration = new TotalDuration("empty");
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
     assertThat(suggestionOutput.getAnalyzerClassname())
         .isEqualTo(QueuingSuggestionProvider.class.getName());
     assertThat(suggestionOutput.getSuggestionList()).isEmpty();
     assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
-    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(TotalDuration.class.getName());
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(QueuingSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
   }
 
   @Test

--- a/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
+++ b/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
@@ -185,7 +185,7 @@ public class ConsoleOutput {
   private String formatDatum(Class<? extends Datum> clazz, Datum datum) {
     var description = datum.getDescription();
     var summary = datum.getSummary();
-    if (!summary.isBlank()) {
+    if (!Strings.isNullOrEmpty(summary)) {
       return String.format(
           "%s: %s%s%s%s",
           format(getClassName(clazz), ConsoleOutputStyle.TEXT_GREEN),


### PR DESCRIPTION
* add `#isEmpty` and `#getEmptyReason` to interface `Datum`
* adjust all `Datum`s, `DataProvider`s and `SuggestionProvider`s to supply better feedback on why `Datum`s are empty or no suggestions were generated.
* return an empty summary for empty `Datum`s

Signed-off-by: Sara Adams <sara.e.adams@googlemail.com>