### PR TITLE
CLI: In verbose mode, include in data dump the reason for empty Datums

### DIFF
--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/core/TestDatum.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/core/TestDatum.java
@@ -140,7 +140,7 @@ public class TestDatum {
 
     @Override
     public String getSummary() {
-      return String.format("My string is %s", myString);
+      return isEmpty() ? null : String.format("My string is %s", myString);
     }
   }
 }

--- a/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
+++ b/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
@@ -200,14 +200,14 @@ public class ConsoleOutput {
 
   private String formatDatum(Class<? extends Datum> clazz, Datum datum) {
     var description = datum.getDescription();
-    var summary = datum.getSummary();
-    if (!Strings.isNullOrEmpty(summary)) {
+    var output = datum.isEmpty() && verbose ? datum.getEmptyReason() : datum.getSummary();
+    if (!Strings.isNullOrEmpty(output)) {
       return String.format(
           "%s: %s%s%s%s",
           format(getClassName(clazz), ConsoleOutputStyle.TEXT_GREEN),
           format(description, ConsoleOutputStyle.TEXT_DIM),
           NEWLINE,
-          summary,
+          output,
           NEWLINE);
     }
     return "";

--- a/cli/javatests/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutputTest.java
+++ b/cli/javatests/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutputTest.java
@@ -27,6 +27,7 @@ import com.engflow.bazel.invocation.analyzer.core.DatumSupplierSpecification;
 import com.engflow.bazel.invocation.analyzer.core.TestDatum.CharDatum;
 import com.engflow.bazel.invocation.analyzer.core.TestDatum.DoubleDatum;
 import com.engflow.bazel.invocation.analyzer.core.TestDatum.IntegerDatum;
+import com.engflow.bazel.invocation.analyzer.core.TestDatum.StringDatum;
 import com.google.common.base.Throwables;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -208,6 +209,7 @@ public class ConsoleOutputTest {
     var myDouble = new DoubleDatum(1.23);
     var myInt = new IntegerDatum(5);
     var myChar = new CharDatum('L');
+    var myEmptyString = new StringDatum(null);
 
     var data =
         new HashMap<Class<? extends DataProvider>, Map<Class<? extends Datum>, Datum>>() {
@@ -218,6 +220,7 @@ public class ConsoleOutputTest {
                   {
                     put(IntegerDatum.class, myInt);
                     put(DoubleDatum.class, myDouble);
+                    put(StringDatum.class, myEmptyString);
                   }
                 });
             put(
@@ -242,6 +245,9 @@ public class ConsoleOutputTest {
     assertThat(result).contains(CharDatum.class.getSimpleName());
     assertThat(result).contains(myChar.getDescription());
     assertThat(result).contains(myChar.getSummary());
+    assertThat(result).contains(myChar.getSummary());
+    assertThat(myEmptyString.getSummary()).isNull();
+    assertThat(result).doesNotContain(myEmptyString.getDescription());
     assertThat(result).doesNotContain(TestDataProvider.class.getSimpleName());
     assertThat(result).doesNotContain(TestDataProvider2.class.getSimpleName());
   }
@@ -251,6 +257,7 @@ public class ConsoleOutputTest {
     var myDouble = new DoubleDatum(1.23);
     var myInt = new IntegerDatum(5);
     var myChar = new CharDatum('L');
+    var myEmptyString = new StringDatum(null);
 
     var data =
         new HashMap<Class<? extends DataProvider>, Map<Class<? extends Datum>, Datum>>() {
@@ -261,6 +268,7 @@ public class ConsoleOutputTest {
                   {
                     put(IntegerDatum.class, myInt);
                     put(DoubleDatum.class, myDouble);
+                    put(StringDatum.class, myEmptyString);
                   }
                 });
             put(
@@ -282,6 +290,10 @@ public class ConsoleOutputTest {
     assertThat(result).contains(DoubleDatum.class.getSimpleName());
     assertThat(result).contains(myDouble.getDescription());
     assertThat(result).contains(myDouble.getSummary());
+    assertThat(result).contains(StringDatum.class.getSimpleName());
+    assertThat(result).contains(myEmptyString.getDescription());
+    assertThat(myEmptyString.getEmptyReason()).isNotEmpty();
+    assertThat(result).contains(myEmptyString.getEmptyReason());
     assertThat(result).contains(CharDatum.class.getSimpleName());
     assertThat(result).contains(myChar.getDescription());
     assertThat(result).contains(myChar.getSummary());


### PR DESCRIPTION
When running the CLI and requesting the data extracted from the Bazel profile, we omit `Datum`s whose summary is empty.
With this change, in verbose mode, the reason why the `Datum` is empty is output (if set), rather than skipping the `Datum`.