### PR TITLE
Analyzer: Add a SuggestionProvider for profiles with little data

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/IncompleteProfileSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/IncompleteProfileSuggestionProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.suggestionproviders;
+
+import com.engflow.bazel.invocation.analyzer.Suggestion;
+import com.engflow.bazel.invocation.analyzer.SuggestionCategory;
+import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.core.DataManager;
+import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
+import com.engflow.bazel.invocation.analyzer.core.SuggestionProvider;
+import com.engflow.bazel.invocation.analyzer.dataproviders.CriticalPathDuration;
+import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedCoresAvailable;
+import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedCoresUsed;
+import com.engflow.bazel.invocation.analyzer.dataproviders.TotalDuration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link SuggestionProvider} that provides suggestions on how to reduce remote execution queuing.
+ */
+public class IncompleteProfileSuggestionProvider extends SuggestionProviderBase {
+  private static final String ANALYZER_CLASSNAME =
+      IncompleteProfileSuggestionProvider.class.getName();
+
+  private static final String SUGGESTION_ID_ANALYZE_DIFFERENT_PROFILE = "AnalyzeDifferentProfile";
+
+  @Override
+  public SuggestionOutput getSuggestions(DataManager dataManager) {
+    try {
+      CriticalPathDuration criticalPathDuration = dataManager.getDatum(CriticalPathDuration.class);
+      TotalDuration totalDuration = dataManager.getDatum(TotalDuration.class);
+      EstimatedCoresAvailable estimatedCoresAvailable =
+          dataManager.getDatum(EstimatedCoresAvailable.class);
+      EstimatedCoresUsed estimatedCoresUsed = dataManager.getDatum(EstimatedCoresUsed.class);
+      List<String> rationaleList = new ArrayList<>();
+      if (criticalPathDuration.isEmpty()) {
+        rationaleList.add("The Bazel profile does not include a critical path.");
+      }
+      if (totalDuration.isEmpty()) {
+        rationaleList.add(
+            "The Bazel profile does not include all data to determine the invocation's duration.");
+      }
+      if (estimatedCoresAvailable.isEmpty()) {
+        rationaleList.add(
+            "The Bazel profile does not include the data required to estimate how many cores were"
+                + " available on the machine that the invocation was run on.");
+      }
+      if (estimatedCoresUsed.isEmpty()) {
+        rationaleList.add(
+            "The Bazel profile does not include the data required to estimate how many cores Bazel"
+                + " used during the invocation.");
+      }
+      if (rationaleList.isEmpty()) {
+        return SuggestionProviderUtil.createSuggestionOutput(ANALYZER_CLASSNAME, null, null);
+      }
+      Suggestion suggestion =
+          SuggestionProviderUtil.createSuggestion(
+              SuggestionCategory.OTHER,
+              createSuggestionId(SUGGESTION_ID_ANALYZE_DIFFERENT_PROFILE),
+              "Analyze a different Bazel profile",
+              "Consider analyzing a different Bazel profile. Many evaluations depend on the profile"
+                  + " reporting some action execution. This will usually be the case when invoking"
+                  + " a build-like Bazel command, such as `bazel build` or `bazel test`.",
+              null,
+              rationaleList,
+              null);
+      return SuggestionProviderUtil.createSuggestionOutput(
+          ANALYZER_CLASSNAME, List.of(suggestion), null);
+    } catch (MissingInputException e) {
+      return SuggestionProviderUtil.createSuggestionOutputForMissingInput(ANALYZER_CLASSNAME, e);
+    } catch (Throwable t) {
+      return SuggestionProviderUtil.createSuggestionOutputForFailure(ANALYZER_CLASSNAME, t);
+    }
+  }
+}

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
@@ -51,6 +51,7 @@ public class SuggestionProviderUtil {
         new JobsSuggestionProvider(),
         new NegligiblePhaseSuggestionProvider(),
         new QueuingSuggestionProvider(),
+        new IncompleteProfileSuggestionProvider(),
         // Consciously put this suggestion last, as it's not about the invocation itself,
         // but guidance on how to potentially get a better analysis using this tool.
         new MergedEventsSuggestionProvider());

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProviderTest.java
@@ -63,9 +63,16 @@ public class CriticalPathDurationDataProviderTest extends DataProviderUnitTestBa
   }
 
   @Test
-  public void shouldBeEmptyWhenCriticalPathIsMissing() throws Exception {
+  public void shouldBeEmptyWhenCriticalPathIsEmpty() throws Exception {
     useProfile(metaData(), trace(mainThread()));
 
+    assertThat(provider.getCriticalPathDuration().getCriticalPathDuration().isEmpty()).isTrue();
+  }
+
+  @Test
+  public void shouldBeEmptyWhenCriticalPathHasNoEvents() throws Exception {
+    useProfile(
+        metaData(), trace(mainThread(), thread(0, 0, BazelProfileConstants.THREAD_CRITICAL_PATH)));
     assertThat(provider.getCriticalPathDuration().getCriticalPathDuration().isEmpty()).isTrue();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BUILD
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BUILD
@@ -11,7 +11,6 @@ java_test(
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//proto:bazel_invocation_analyzer_java_proto",
-        "//third_party/jsr305",
         "//third_party/junit",
         "//third_party/mockito",
         "//third_party/truth",

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/IncompleteProfileSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/IncompleteProfileSuggestionProviderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.suggestionproviders;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.dataproviders.CriticalPathDuration;
+import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedCoresAvailable;
+import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedCoresUsed;
+import com.engflow.bazel.invocation.analyzer.dataproviders.TotalDuration;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IncompleteProfileSuggestionProviderTest extends SuggestionProviderUnitTestBase {
+  // These variables are returned from calls to DataManager.getDatum for the associated types. They
+  // are set up with reasonable defaults before each test is run, but can be overridden within the
+  // tests when custom values are desired for the testing being conducted (without the need to
+  // re-initialize the mocking).
+  private CriticalPathDuration criticalPathDuration;
+  private TotalDuration totalDuration;
+  private EstimatedCoresAvailable estimatedCoresAvailable;
+  private EstimatedCoresUsed estimatedCoresUsed;
+
+  @Before
+  public void setup() throws Exception {
+    // Create reasonable defaults and set up to return the class-variables when the associated types
+    // are requested.
+    criticalPathDuration = new CriticalPathDuration(Duration.ofSeconds(10));
+    when(dataManager.getDatum(CriticalPathDuration.class)).thenAnswer(i -> criticalPathDuration);
+    totalDuration = new TotalDuration(Duration.ofSeconds(60));
+    when(dataManager.getDatum(TotalDuration.class)).thenAnswer(i -> totalDuration);
+    estimatedCoresAvailable = new EstimatedCoresAvailable(16, 0);
+    when(dataManager.getDatum(EstimatedCoresAvailable.class))
+        .thenAnswer(i -> estimatedCoresAvailable);
+    estimatedCoresUsed = new EstimatedCoresUsed(8, 0);
+    when(dataManager.getDatum(EstimatedCoresUsed.class)).thenAnswer(i -> estimatedCoresUsed);
+
+    suggestionProvider = new IncompleteProfileSuggestionProvider();
+  }
+
+  @Test
+  public void shouldNotReturnSuggestionIfDataIsPresent() throws Exception {
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(IncompleteProfileSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getCaveatList()).isEmpty();
+    assertThat(suggestionOutput.getMissingInputList()).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnSuggestionForEmptyCriticalPathDuration() {
+    criticalPathDuration = new CriticalPathDuration("empty");
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(IncompleteProfileSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).isNotEmpty();
+  }
+
+  @Test
+  public void shouldReturnSuggestionForEmptyEstimatedCoresAvailable() {
+    estimatedCoresAvailable = new EstimatedCoresAvailable("empty");
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(IncompleteProfileSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).isNotEmpty();
+  }
+
+  @Test
+  public void shouldReturnSuggestionForEmptyEstimatedCoresUsed() {
+    estimatedCoresUsed = new EstimatedCoresUsed("empty");
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(IncompleteProfileSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).isNotEmpty();
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
@@ -23,6 +23,7 @@ import org.junit.runners.Suite;
   BuildWithoutTheBytesSuggestionProviderTest.class,
   CriticalPathNotDominantSuggestionProviderTest.class,
   GarbageCollectionSuggestionProviderTest.class,
+  IncompleteProfileSuggestionProviderTest.class,
   JobsSuggestionProviderTest.class,
   MergedEventsSuggestionProviderTest.class,
   NegligiblePhaseSuggestionProviderTest.class,


### PR DESCRIPTION
Many of the `SuggestionProvider`s only supply suggestions if the Bazel profile was generated for a build-like command. This change adds a suggestion to analyze such a profile if the passed in profile looks like it was generated for a non-build-like command (e.g. query).

Example output:
```text
Suggestion: "Analyze a different Bazel profile"
Consider analyzing a different Bazel profile. Many evaluations depend on the profile reporting some action execution. This will usually be the case when invoking a build-like Bazel command, such as `bazel build` or `bazel test`.
Rationale
The Bazel profile does not include a critical path.
The Bazel profile does not include the data required to estimate how many cores were available on the machine that the invocation was run on.
The Bazel profile does not include the data required to estimate how many cores Bazel used during the invocation.
```