### PR TITLE
Core: Avoid NPEs on invalid Bazel profiles

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
@@ -98,12 +98,15 @@ public class BazelProfile implements Datum {
         .forEach(
             element -> {
               JsonObject object = element.getAsJsonObject();
-              if (!object.has(TraceEventFormatConstants.EVENT_PROCESS_ID)
-                  || !object.has(TraceEventFormatConstants.EVENT_THREAD_ID)) {
+              int pid;
+              int tid;
+              try {
+                pid = object.get(TraceEventFormatConstants.EVENT_PROCESS_ID).getAsInt();
+                tid = object.get(TraceEventFormatConstants.EVENT_THREAD_ID).getAsInt();
+              } catch (Exception e) {
+                // Skip events that do not have a valid pid or tid.
                 return;
               }
-              int pid = object.get(TraceEventFormatConstants.EVENT_PROCESS_ID).getAsInt();
-              int tid = object.get(TraceEventFormatConstants.EVENT_THREAD_ID).getAsInt();
               ThreadId threadId = new ThreadId(pid, tid);
               ProfileThread profileThread =
                   threads.compute(

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
@@ -182,7 +182,7 @@ public class ProfileThread {
       }
 
       return true;
-    } catch (IllegalArgumentException ex) {
+    } catch (Exception ex) {
       return false;
     }
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/WriteBazelProfile.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/WriteBazelProfile.java
@@ -18,6 +18,7 @@ import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.Property.p
 import static java.nio.file.Files.newBufferedWriter;
 import static java.nio.file.Files.newOutputStream;
 
+import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
 import com.engflow.bazel.invocation.analyzer.time.TimeUtil;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import com.engflow.bazel.invocation.analyzer.traceeventformat.TraceEventFormatConstants;
@@ -80,6 +81,17 @@ public class WriteBazelProfile {
       throw new RuntimeException(e);
     }
     return file;
+  }
+
+  /**
+   * Create a new main thread for the {@link #trace(TraceEvent...)}.
+   *
+   * @param events a series of events that belong to the thread
+   * @return an instance of {@link TraceEvent} to be serialized to json.
+   */
+  @CheckReturnValue
+  public static TraceEvent mainThread(ThreadEvent... events) {
+    return thread(-1, 0, BazelProfileConstants.THREAD_MAIN, events);
   }
 
   /**

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProviderTest.java
@@ -15,6 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
@@ -45,6 +46,7 @@ public class CriticalPathDurationDataProviderTest extends DataProviderUnitTestBa
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -62,7 +64,7 @@ public class CriticalPathDurationDataProviderTest extends DataProviderUnitTestBa
 
   @Test
   public void shouldBeEmptyWhenCriticalPathIsMissing() throws Exception {
-    useProfile(metaData(), trace());
+    useProfile(metaData(), trace(mainThread()));
 
     assertThat(provider.getCriticalPathDuration().getCriticalPathDuration().isEmpty()).isTrue();
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
@@ -15,6 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
@@ -57,6 +58,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             skyFrameThread(0, start, Duration.ZERO),
             skyFrameThread(1, end, Duration.ZERO),
             skyFrameThread(2, within, Duration.ZERO),
@@ -84,6 +86,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             skyFrameThread(maxIndexInRelevantPhase - 1, start, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase - 2, within, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase, end, Duration.ZERO),
@@ -111,6 +114,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
 
@@ -136,6 +140,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
 
@@ -161,6 +166,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
 
@@ -182,6 +188,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             skyFrameThread(0, start, Duration.ZERO),
             skyFrameThread(1, start, Duration.ZERO),
             skyFrameThread(2, start, Duration.ZERO),
@@ -206,6 +213,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             skyFrameThread(0, outsideRangeAfter, Duration.ZERO),
             skyFrameThread(1, start, Duration.ZERO),
             skyFrameThread(2, start, Duration.ZERO),
@@ -233,6 +241,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             skyFrameThread(0, outsideRangeBefore, Duration.ZERO),
             skyFrameThread(1, within2, Duration.ZERO),
             skyFrameThread(2, outsideRangeAfter, Duration.ZERO),

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStatsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStatsDataProviderTest.java
@@ -16,6 +16,7 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.concat;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
@@ -47,6 +48,7 @@ public class GarbageCollectionStatsDataProviderTest extends DataProviderUnitTest
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -73,6 +75,7 @@ public class GarbageCollectionStatsDataProviderTest extends DataProviderUnitTest
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/MergedEventsPresentDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/MergedEventsPresentDataProviderTest.java
@@ -15,6 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
@@ -40,6 +41,7 @@ public class MergedEventsPresentDataProviderTest extends DataProviderUnitTestBas
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 20,
                 0,
@@ -59,6 +61,7 @@ public class MergedEventsPresentDataProviderTest extends DataProviderUnitTestBas
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 20,
                 0,

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProviderTest.java
@@ -16,6 +16,7 @@ package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.concat;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
@@ -50,6 +51,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -101,6 +103,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -154,6 +157,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -204,6 +208,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -250,6 +255,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -290,7 +296,8 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
 
   @Test
   public void shouldReturnZeroQueuingDurationWhenCriticalPathIsEmpty() throws Exception {
-    useProfile(metaData(), trace(thread(0, 0, BazelProfileConstants.THREAD_CRITICAL_PATH)));
+    useProfile(
+        metaData(), trace(mainThread(), thread(0, 0, BazelProfileConstants.THREAD_CRITICAL_PATH)));
 
     assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().get())
         .isEqualTo(Duration.ZERO);
@@ -298,7 +305,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
 
   @Test
   public void shouldBeEmptyWhenCriticalPathIsMissing() throws Exception {
-    useProfile(metaData(), trace());
+    useProfile(metaData(), trace(mainThread()));
 
     assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().isEmpty())
         .isTrue();

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/QueuingObservedDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/QueuingObservedDataProviderTest.java
@@ -15,6 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
@@ -43,6 +44,7 @@ public class QueuingObservedDataProviderTest extends DataProviderUnitTestBase {
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -58,7 +60,7 @@ public class QueuingObservedDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void shouldReturnQueuingNotObserved() throws Exception {
-    useProfile(metaData(), trace());
+    useProfile(metaData(), trace(mainThread()));
 
     assertThat(provider.getQueuingObserved().isQueuingObserved()).isFalse();
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteCachingUsedDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteCachingUsedDataProviderTest.java
@@ -15,6 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
@@ -43,6 +44,7 @@ public class RemoteCachingUsedDataProviderTest extends DataProviderUnitTestBase 
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -58,7 +60,7 @@ public class RemoteCachingUsedDataProviderTest extends DataProviderUnitTestBase 
 
   @Test
   public void shouldReturnRemoteCachingNotUsed() throws Exception {
-    useProfile(metaData(), trace());
+    useProfile(metaData(), trace(mainThread()));
 
     assertThat(provider.getRemoteCachingUsed().isRemoteCachingUsed()).isFalse();
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProviderTest.java
@@ -15,6 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
@@ -43,6 +44,7 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -61,6 +63,7 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -79,6 +82,7 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -94,7 +98,7 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
 
   @Test
   public void shouldReturnRemoteExecutionNotUsedForEmptyProfile() throws Exception {
-    useProfile(metaData(), trace());
+    useProfile(metaData(), trace(mainThread()));
 
     assertThat(provider.getRemoteExecutionUsed().isRemoteExecutionUsed()).isFalse();
   }
@@ -105,6 +109,7 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/TotalQueuingDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/TotalQueuingDurationDataProviderTest.java
@@ -15,6 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
@@ -49,6 +50,7 @@ public class TotalQueuingDurationDataProviderTest extends DataProviderUnitTestBa
     useProfile(
         metaData(),
         trace(
+            mainThread(),
             thread(
                 0,
                 0,
@@ -69,7 +71,7 @@ public class TotalQueuingDurationDataProviderTest extends DataProviderUnitTestBa
 
   @Test
   public void shouldReturnZeroQueuingDuration() throws Exception {
-    useProfile(metaData(), trace());
+    useProfile(metaData(), trace(mainThread()));
 
     TotalQueuingDuration queuing = provider.getTotalQueuingDuration();
     verify(dataManager).registerProvider(provider);

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProviderTest.java
@@ -20,13 +20,11 @@ import static org.mockito.Mockito.when;
 import com.engflow.bazel.invocation.analyzer.Suggestion;
 import com.engflow.bazel.invocation.analyzer.SuggestionCategory;
 import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
-import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
 import com.engflow.bazel.invocation.analyzer.dataproviders.GarbageCollectionStats;
 import com.engflow.bazel.invocation.analyzer.dataproviders.TotalDuration;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import java.time.Duration;
 import java.util.Locale;
-import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +33,7 @@ public class GarbageCollectionSuggestionProviderTest extends SuggestionProviderU
   // are set up with reasonable defaults before each test is run, but can be overridden within the
   // tests when custom values are desired for the testing being conducted (without the need to
   // re-initialize the mocking).
-  @Nullable private GarbageCollectionStats garbageCollectionStats;
+  private GarbageCollectionStats garbageCollectionStats;
   private TotalDuration totalDuration;
 
   @Before
@@ -49,22 +47,6 @@ public class GarbageCollectionSuggestionProviderTest extends SuggestionProviderU
     when(dataManager.getDatum(TotalDuration.class)).thenAnswer(i -> totalDuration);
 
     suggestionProvider = new GarbageCollectionSuggestionProvider();
-  }
-
-  @Test
-  public void shouldNotReturnSuggestionForMissingGarbageCollectionStats() throws Exception {
-    when(dataManager.getDatum(GarbageCollectionStats.class))
-        .thenThrow(new MissingInputException(GarbageCollectionStats.class));
-
-    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
-
-    assertThat(suggestionOutput.getAnalyzerClassname())
-        .isEqualTo(GarbageCollectionSuggestionProvider.class.getName());
-    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
-    assertThat(suggestionOutput.hasFailure()).isFalse();
-    assertThat(suggestionOutput.getMissingInputList()).hasSize(1);
-    assertThat(suggestionOutput.getMissingInput(0))
-        .isEqualTo(GarbageCollectionStats.class.getName());
   }
 
   @Test


### PR DESCRIPTION
Fixes #54

When passing in valid json files that are missing key components of a Bazel profile, an NPE is thrown.
This change checks for the key components before trying to access them and throws an IllegalArgumentException if the components do not exist.