### PR TITLE
BazelProfile: In summary, include data about threads

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
@@ -190,7 +190,7 @@ public class BazelProfile implements Datum {
 
   @Override
   public String getDescription() {
-    return "The JSON profile written by Bazel.";
+    return "The profile written by Bazel.";
   }
 
   @Override


### PR DESCRIPTION
To ease debugging, extend `BazelProfile#getSummary` to include some data about the threads found.

Example output:
```
BazelProfile: The profile written by Bazel.
Threads:
"Critical Path"                     	CompleteEvents: 1
"Garbage Collector"                 	CompleteEvents: 1
"Main Thread"                       	CompleteEvents: 2630	Counts: 5	Instants: 2
"skyframe-evaluator 0"              	CompleteEvents: 47
"skyframe-evaluator 1"              	CompleteEvents: 51
"skyframe-evaluator 10"             	CompleteEvents: 56
"skyframe-evaluator 11"             	CompleteEvents: 42
"skyframe-evaluator 12"             	CompleteEvents: 37
"skyframe-evaluator 13"             	CompleteEvents: 42
"skyframe-evaluator 14"             	CompleteEvents: 42
"skyframe-evaluator 15"             	CompleteEvents: 56
"skyframe-evaluator 2"              	CompleteEvents: 42
"skyframe-evaluator 3"              	CompleteEvents: 42
"skyframe-evaluator 4"              	CompleteEvents: 56
"skyframe-evaluator 5"              	CompleteEvents: 56
"skyframe-evaluator 6"              	CompleteEvents: 42
"skyframe-evaluator 7"              	CompleteEvents: 42
"skyframe-evaluator 8"              	CompleteEvents: 42
"skyframe-evaluator 9"              	CompleteEvents: 51

Critical Path:
Duration	Description
...
```