### PR TITLE
RemoteExecutionUsed: Avoid false positives with stricter checks

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
@@ -31,6 +31,7 @@ public class BazelProfileConstants {
   public static final String CAT_GARBAGE_COLLECTION = "gc notification";
   public static final String CAT_GENERAL_INFORMATION = "general information";
   public static final String CAT_REMOTE_ACTION_CACHE_CHECK = "remote action cache check";
+  public static final String CAT_REMOTE_ACTION_EXECUTION = "remote action execution";
   public static final String CAT_REMOTE_EXECUTION_PROCESS_WALL_TIME =
       "Remote execution process wall time";
   public static final String CAT_REMOTE_EXECUTION_QUEUING_TIME = "Remote execution queuing time";
@@ -44,6 +45,7 @@ public class BazelProfileConstants {
   // CompleteEvent names
   public static final String COMPLETE_MAJOR_GARBAGE_COLLECTION = "major GC";
   public static final String COMPLETE_MINOR_GARBAGE_COLLECTION = "minor GC";
+  public static final String COMPLETE_EXECUTE_REMOTELY = "execute remotely";
 
   // InstantEvent names
   public static final String INSTANT_FINISHING = "Finishing";

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProvider.java
@@ -49,9 +49,9 @@ public class RemoteExecutionUsedDataProvider extends DataProvider {
             .anyMatch(
                 (event) ->
                     BazelProfileConstants.CAT_REMOTE_EXECUTION_SETUP.equals(event.category)
-                        || BazelProfileConstants.CAT_REMOTE_EXECUTION_PROCESS_WALL_TIME.equals(
-                            event.category)
                         || BazelProfileConstants.CAT_REMOTE_EXECUTION_QUEUING_TIME.equals(
-                            event.category)));
+                            event.category)
+                        || BazelProfileConstants.CAT_REMOTE_ACTION_EXECUTION.equals(event.category)
+                            && BazelProfileConstants.COMPLETE_EXECUTE_REMOTELY.equals(event.name)));
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProviderTest.java
@@ -40,7 +40,7 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
   }
 
   @Test
-  public void shouldReturnRemoteExecutionUsedOnRemoteExecutionProcessWallTime() throws Exception {
+  public void shouldReturnRemoteExecutionUsedOnRemoteActionExecution() throws Exception {
     useProfile(
         metaData(),
         trace(
@@ -50,8 +50,8 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
                 0,
                 "foo",
                 complete(
-                    "bar",
-                    BazelProfileConstants.CAT_REMOTE_EXECUTION_PROCESS_WALL_TIME,
+                    BazelProfileConstants.COMPLETE_EXECUTE_REMOTELY,
+                    BazelProfileConstants.CAT_REMOTE_ACTION_EXECUTION,
                     Timestamp.ofMicros(123),
                     Duration.ZERO))));
 
@@ -94,6 +94,25 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
                     Duration.ZERO))));
 
     assertThat(provider.getRemoteExecutionUsed().isRemoteExecutionUsed()).isTrue();
+  }
+
+  @Test
+  public void shouldReturnRemoteExecutionNotUsedOnRemoteExecutionProcessingTime() throws Exception {
+    useProfile(
+        metaData(),
+        trace(
+            mainThread(),
+            thread(
+                0,
+                0,
+                "foo",
+                complete(
+                    "bar",
+                    BazelProfileConstants.CAT_REMOTE_EXECUTION_PROCESS_WALL_TIME,
+                    Timestamp.ofMicros(123),
+                    Duration.ZERO))));
+
+    assertThat(provider.getRemoteExecutionUsed().isRemoteExecutionUsed()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Currently `RemoteExecutionUsedDataProvider` is too lenient with how it checks whether remote execution was likely used. This leads to false positives, in particular when using remote caching or a disk cache.
Instead of checking for events with the category `Remote execution process wall time`, which also occurs for non-RE builds, now check for events with the category `remote action execution` and name `execute remotely`. This seems to be a stronger signal for remote execution.

Progress on #60