### PR TITLE
DurationUtil: add convenience method `getPercentageOf`

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
@@ -50,20 +50,20 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
   static final String SUGGESTION_ID_AVOID_BOTTLENECKS_DUE_TO_QUEUING =
       "AvoidBottlenecksDueToQueuing";
 
-  private static final double SIGNIFICANT_QUEUING_RATIO = .2;
+  private static final double SIGNIFICANT_QUEUING_PERCENTAGE = 20;
 
   private final Duration minDuration;
   private final int maxSuggestions;
   private final int maxActionsPerBottleneck;
-  private final double minImprovementRatio;
+  private final double minImprovementPercentage;
   private final double maxActionCountRatio;
 
   /**
    * @param maxSuggestions the maximum number of bottlenecks suggested by this provider
    * @param maxActionsPerBottleneck the maximum number of actions listed per bottleneck suggestion
    * @param minDuration the minimum duration of a bottleneck for it to be suggested
-   * @param minImprovementRatio the minimum improvement you'd get out of fixing a bottleneck for it
-   *     to be suggested, where the improvement is the 1 -
+   * @param minImprovementPercentage the minimum improvement you'd get out of fixing a bottleneck
+   *     for it to be suggested, where the improvement is the 100 -
    *     (theoretical_wall_duration_without_bottleneck / wall_duration_with_bottleneck)
    * @param maxActionCountRatio the maximum ratio for (bottleneck action count / cores used in
    *     invocation) for a bottleneck to be suggested
@@ -73,12 +73,12 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
       int maxSuggestions,
       int maxActionsPerBottleneck,
       Duration minDuration,
-      double minImprovementRatio,
+      double minImprovementPercentage,
       double maxActionCountRatio) {
     this.maxSuggestions = maxSuggestions;
     this.maxActionsPerBottleneck = maxActionsPerBottleneck;
     this.minDuration = minDuration;
-    this.minImprovementRatio = minImprovementRatio;
+    this.minImprovementPercentage = minImprovementPercentage;
     this.maxActionCountRatio = maxActionCountRatio;
   }
 
@@ -118,10 +118,12 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
                   bottleneck ->
                       BottleneckStats.fromBottleneckAndCoresAndWallDuration(
                           bottleneck, coresUsed, totalDuration))
-              .filter(bottleneckStats -> bottleneckStats.improvement >= minImprovementRatio)
+              .filter(
+                  bottleneckStats ->
+                      bottleneckStats.improvementPercentage >= minImprovementPercentage)
               .sorted(
                   Comparator.<BottleneckStats>comparingDouble(
-                          bottleneckStats -> bottleneckStats.improvement)
+                          bottleneckStats -> bottleneckStats.improvementPercentage)
                       .reversed())
               .limit(maxSuggestions)
               .map(bottleneckStats -> generateSuggestion(bottleneckStats, totalDuration))
@@ -187,16 +189,16 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
     }
 
     Duration maxQueuingDuration = bottleneck.bottleneck.getMaxQueuingDuration();
-    double ratio =
-        maxQueuingDuration.toMillis() / (double) bottleneck.bottleneck.getDuration().toMillis();
+    double percentage =
+        DurationUtil.getPercentageOf(maxQueuingDuration, bottleneck.bottleneck.getDuration());
     String bottleneckQueuingData =
         String.format(
             Locale.US,
             "This bottleneck includes queuing for up to %s, which is %.2f%% of the bottleneck's"
                 + " duration.",
             DurationUtil.formatDuration(maxQueuingDuration),
-            100 * ratio);
-    if (ratio > SIGNIFICANT_QUEUING_RATIO) {
+            percentage);
+    if (percentage > SIGNIFICANT_QUEUING_PERCENTAGE) {
       recommendation.append(
           "\n"
               + "The bottleneck includes significant queuing.\n"
@@ -213,7 +215,7 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
           rationale,
           caveats);
     } else {
-      if (ratio > 0) {
+      if (percentage > 0) {
         caveats.add(SuggestionProviderUtil.createCaveat(bottleneckQueuingData, false));
       }
       recommendation.append("\nTry breaking them down into smaller actions.");
@@ -254,33 +256,33 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
 
   private PotentialImprovement potentialImprovement(
       BottleneckStats bottleneck, Duration totalDuration) {
-    double percentage = 100 * bottleneck.improvement;
     String message =
         String.format(
             "The initial build time was %s and could be reduced to %s.",
             formatDuration(totalDuration), formatDuration(bottleneck.optimalWallDuration));
-    return SuggestionProviderUtil.createPotentialImprovement(message, percentage);
+    return SuggestionProviderUtil.createPotentialImprovement(
+        message, bottleneck.improvementPercentage);
   }
 
   public static BottleneckSuggestionProvider createDefault() {
-    return new BottleneckSuggestionProvider(5, 5, Duration.ofSeconds(5), .05, .9);
+    return new BottleneckSuggestionProvider(5, 5, Duration.ofSeconds(5), 5, .9);
   }
 
   public static BottleneckSuggestionProvider createVerbose() {
     return new BottleneckSuggestionProvider(
-        Integer.MAX_VALUE, Integer.MAX_VALUE, Duration.ZERO, .0, .0);
+        Integer.MAX_VALUE, Integer.MAX_VALUE, Duration.ZERO, 0, .0);
   }
 
   private static class BottleneckStats {
     private final Bottleneck bottleneck;
     private final Duration optimalWallDuration;
-    private final double improvement;
+    private final double improvementPercentage;
 
     private BottleneckStats(
-        Bottleneck bottleneck, Duration optimalWallDuration, double improvement) {
+        Bottleneck bottleneck, Duration optimalWallDuration, double improvementPercentage) {
       this.bottleneck = bottleneck;
       this.optimalWallDuration = optimalWallDuration;
-      this.improvement = improvement;
+      this.improvementPercentage = improvementPercentage;
     }
 
     private static BottleneckStats fromBottleneckAndCoresAndWallDuration(
@@ -293,7 +295,7 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
       final var optimalWallDuration =
           totalDuration.minus(bottleneck.getDuration()).plus(optimalBottleneckDuration);
       final var improvement =
-          1 - optimalWallDuration.toMillis() / (double) totalDuration.toMillis();
+          100 - DurationUtil.getPercentageOf(optimalWallDuration, totalDuration);
       return new BottleneckStats(bottleneck, optimalWallDuration, improvement);
     }
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
@@ -63,7 +63,7 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
    * @param maxActionsPerBottleneck the maximum number of actions listed per bottleneck suggestion
    * @param minDuration the minimum duration of a bottleneck for it to be suggested
    * @param minImprovementPercentage the minimum improvement you'd get out of fixing a bottleneck
-   *     for it to be suggested, where the improvement is the 100 -
+   *     for it to be suggested, where the improvement is 100 -
    *     (theoretical_wall_duration_without_bottleneck / wall_duration_with_bottleneck)
    * @param maxActionCountRatio the maximum ratio for (bottleneck action count / cores used in
    *     invocation) for a bottleneck to be suggested

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProvider.java
@@ -59,9 +59,8 @@ public class GarbageCollectionSuggestionProvider extends SuggestionProviderBase 
         }
         Duration totalDuration = totalDurationDatum.getTotalDuration().get();
         double percentOfTotal =
-            100.0
-                * gcStats.getMajorGarbageCollectionDuration().toMillis()
-                / totalDuration.toMillis();
+            DurationUtil.getPercentageOf(
+                gcStats.getMajorGarbageCollectionDuration(), totalDuration);
         if (percentOfTotal >= MAJOR_GC_MIN_PERCENTAGE) {
           Duration optimalDuration =
               totalDuration.minus(gcStats.getMajorGarbageCollectionDuration());

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProvider.java
@@ -90,7 +90,7 @@ public class NegligiblePhaseSuggestionProvider extends SuggestionProviderBase {
           continue;
         }
         Duration phaseDuration = optionalPhaseDescription.get().getDuration();
-        double percentOfTotal = phaseDuration.toMillis() / (double) totalDuration.toMillis() * 100;
+        double percentOfTotal = DurationUtil.getPercentageOf(phaseDuration, totalDuration);
         if (percentOfTotal > PCT_THRESHOLD) {
           String title = "Unusual Phase Duration";
           String recommendation =

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/QueuingSuggestionProvider.java
@@ -81,7 +81,7 @@ public class QueuingSuggestionProvider extends SuggestionProviderBase {
           }
           Duration totalDuration = totalDurationDatum.getTotalDuration().get();
           double invocationDurationReductionPercentage =
-              100 * queuingDuration.toMillis() / (double) totalDuration.toMillis();
+              DurationUtil.getPercentageOf(queuingDuration, totalDuration);
           potentialImprovement =
               SuggestionProviderUtil.createPotentialImprovement(
                   String.format(
@@ -90,9 +90,8 @@ public class QueuingSuggestionProvider extends SuggestionProviderBase {
                           + " reduced by %.2f%%, from %s to %s.",
                       DurationUtil.formatDuration(queuingDuration),
                       100
-                          * (1
-                              - criticalPathDuration.minus(queuingDuration).toMillis()
-                                  / (double) criticalPathDuration.toMillis()),
+                          - DurationUtil.getPercentageOf(
+                              criticalPathDuration.minus(queuingDuration), criticalPathDuration),
                       DurationUtil.formatDuration(criticalPathDuration),
                       DurationUtil.formatDuration(criticalPathDuration.minus(queuingDuration))),
                   invocationDurationReductionPercentage);

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/time/DurationUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/time/DurationUtil.java
@@ -40,4 +40,18 @@ public class DurationUtil {
       return String.format("%dms", duration.toMillis());
     }
   }
+
+  /**
+   * Returns the percentage of one duration relative to another duration.
+   *
+   * @param partial The duration to return the percentage of related to base
+   * @param base The duration to base the percentage on
+   * @return the percentage of partial relative to base
+   */
+  public static double getPercentageOf(Duration partial, Duration base) {
+    if (base.isZero()) {
+      throw new IllegalArgumentException("Duration base must not be zero.");
+    }
+    return 100.0 * partial.toNanos() / base.toNanos();
+  }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProviderTest.java
@@ -49,7 +49,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
         .thenReturn(new TotalDuration(Duration.ofSeconds(100)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -69,7 +69,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
         .thenReturn(new TotalDuration(Duration.ofSeconds(100)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -87,7 +87,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(TotalDuration.class)).thenReturn(new TotalDuration("empty"));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -106,7 +106,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of()));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -129,7 +129,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, minDuration, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, minDuration, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -151,7 +151,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).hasSize(1);
     assertThat(suggestions.hasFailure()).isFalse();
@@ -174,7 +174,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).hasSize(1);
     assertThat(suggestions.getSuggestion(0).getId())
@@ -199,7 +199,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).hasSize(1);
     assertThat(suggestions.getSuggestion(0).getId())
@@ -223,7 +223,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 1., 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 100, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -249,7 +249,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
 
     final var bottleneckSuggestionProvider =
         new BottleneckSuggestionProvider(
-            1, 1, Duration.ZERO, 1., actionCountSample / (double) (coresUsed + 1));
+            1, 1, Duration.ZERO, 100, actionCountSample / (double) (coresUsed + 1));
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -276,7 +276,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
         .thenReturn(new ActionStats(List.of(minorBottleneck, majorBottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, .0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionCount()).isEqualTo(1);
     assertThat(suggestions.getSuggestion(0).getRationaleCount()).isEqualTo(1);

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/time/DurationUtilTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/time/DurationUtilTest.java
@@ -15,13 +15,15 @@
 package com.engflow.bazel.invocation.analyzer.time;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import org.junit.Test;
 
 public class DurationUtilTest {
   @Test
-  public void formatHours() throws Exception {
+  public void formatHours() {
     assertThat(DurationUtil.formatDuration(Duration.ofHours(1))).isEqualTo("1h 0m 0s");
     assertThat(DurationUtil.formatDuration(Duration.ofHours(1).plus(Duration.ofSeconds(2))))
         .isEqualTo("1h 0m 2s");
@@ -29,7 +31,7 @@ public class DurationUtilTest {
   }
 
   @Test
-  public void formatMinutes() throws Exception {
+  public void formatMinutes() {
     assertThat(DurationUtil.formatDuration(Duration.ofMinutes(1))).isEqualTo("1m 0s");
     assertThat(DurationUtil.formatDuration(Duration.ofMinutes(1).plus(Duration.ofSeconds(2))))
         .isEqualTo("1m 2s");
@@ -37,16 +39,54 @@ public class DurationUtilTest {
   }
 
   @Test
-  public void formatSeconds() throws Exception {
+  public void formatSeconds() {
     assertThat(DurationUtil.formatDuration(Duration.ofSeconds(10).plus(Duration.ofMillis(10))))
         .isEqualTo("10s");
     assertThat(DurationUtil.formatDuration(Duration.ofSeconds(59))).isEqualTo("59s");
   }
 
   @Test
-  public void formatMilliseconds() throws Exception {
+  public void formatMilliseconds() {
     assertThat(DurationUtil.formatDuration(Duration.ofSeconds(1))).isEqualTo("1000ms");
     assertThat(DurationUtil.formatDuration(Duration.ofSeconds(9).plus(Duration.ofMillis(42))))
         .isEqualTo("9042ms");
+  }
+
+  @Test
+  public void getPercentageOfZeroBase() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DurationUtil.getPercentageOf(Duration.ofSeconds(1), Duration.ZERO));
+  }
+
+  @Test
+  public void getPercentageOfZeroFraction() {
+    assertThat(DurationUtil.getPercentageOf(Duration.ZERO, Duration.ofSeconds(4))).isEqualTo(0);
+  }
+
+  @Test
+  public void getPercentageOfFraction() {
+    assertThat(DurationUtil.getPercentageOf(Duration.ofSeconds(1), Duration.ofSeconds(4)))
+        .isEqualTo(25);
+  }
+
+  @Test
+  public void getPercentageOfMultiple() {
+    assertThat(DurationUtil.getPercentageOf(Duration.ofSeconds(4), Duration.ofSeconds(2)))
+        .isEqualTo(200);
+  }
+
+  @Test
+  public void getPercentageOfYears() {
+    assertThat(DurationUtil.getPercentageOf(Duration.ofDays(4 * 365), Duration.ofDays(5 * 365)))
+        .isEqualTo(80);
+  }
+
+  @Test
+  public void getPercentageOfMicros() {
+    assertThat(
+            DurationUtil.getPercentageOf(
+                Duration.of(200, ChronoUnit.MICROS), Duration.of(5000, ChronoUnit.MICROS)))
+        .isEqualTo(4);
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/time/DurationUtilTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/time/DurationUtilTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import org.junit.Test;
 
 public class DurationUtilTest {
@@ -83,10 +82,8 @@ public class DurationUtilTest {
   }
 
   @Test
-  public void getPercentageOfMicros() {
-    assertThat(
-            DurationUtil.getPercentageOf(
-                Duration.of(200, ChronoUnit.MICROS), Duration.of(5000, ChronoUnit.MICROS)))
+  public void getPercentageOfNanos() {
+    assertThat(DurationUtil.getPercentageOf(Duration.ofNanos(200), Duration.ofNanos(5000)))
         .isEqualTo(4);
   }
 }


### PR DESCRIPTION
We are calculating the percentage of durations in multiple places. This change introduces a convenience method to ensure these calculations are all consistent, and replaces the individual implementations with a call to the new method.