### PR TITLE
ActionStats: Better singular/plural handling in `getSummary`

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStats.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStats.java
@@ -73,7 +73,9 @@ public class ActionStats implements Datum {
     var duration =
         bottlenecks.get().stream().map(b -> b.getDuration()).reduce(Duration.ZERO, Duration::plus);
     return String.format(
-        "%d bottlenecks found for a total duration of %s.",
-        bottlenecks.get().size(), DurationUtil.formatDuration(duration));
+        "%d %s found for a total duration of %s.",
+        bottlenecks.get().size(),
+        bottlenecks.get().size() == 1 ? "bottleneck" : "bottlenecks",
+        DurationUtil.formatDuration(duration));
   }
 }


### PR DESCRIPTION
Currently, when there's exactly one bottleneck, `getSummary` returns `1 bottlenecks found`. This change ensures we return `1 bottleneck found` instead.