### PR TITLE
Docs: Link to relevant FAQ question

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ We welcome contributions from the community. Read our [guide to contributing](ht
 
 ## References
 
-- [Generating a Bazel profile](https://docs.engflow.com/docs/re/faq.html)
+- [Generating a Bazel profile](https://docs.engflow.com/docs/re/faq.html#how-do-i-capture-a-bazel-profile)
 - [Interpreting a Bazel profile](https://bazel.build/rules/performance#performance-profiling)


### PR DESCRIPTION
Update the link on how to generate a Bazel profile to link to the correct heading.
Follow-up to https://github.com/EngFlow/bazel_invocation_analyzer/pull/70#discussion_r1008332933