### PR TITLE
Docs: Update contact email address to analyzer@engflow.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -31,7 +31,7 @@ A clear and concise description of what the behavior should be.
 Supplemental data helps debug issues more quickly and reliably.
 
 Provide as many details as you feel comfortable sharing publicly.
-Alternatively, email data to <bazel-invocation-analyzer-dev@engflow.com> while referencing the
+Alternatively, email data to <analyzer@engflow.com> while referencing the
 created issue, or opt to send the bug report entirely by email.
 
 ### Environment

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -29,7 +29,7 @@ If proposing different solutions, present each one separately.
 Supplemental data helps evaluate and implement feature requests more quickly and reliably.
 
 Provide as many details as you feel comfortable sharing publicly.
-Alternatively, email data to <bazel-invocation-analyzer-dev@engflow.com> while referencing the
+Alternatively, email data to <analyzer@engflow.com> while referencing the
 created issue, or opt to send the feature request entirely by email.
 
 For example, you may want to include example files, reference other issues, etc.

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -15,7 +15,7 @@ Leave your feedback here.
 Supplemental data gives context for the feedback and makes it easier to act on, where appropriate.
 
 Provide as many details as you feel comfortable sharing publicly.
-Alternatively, email data to <bazel-invocation-analyzer-dev@engflow.com> while referencing the
+Alternatively, email data to <analyzer@engflow.com> while referencing the
 created issue, or opt to send the feedback entirely by email.
 
 ### Output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ We welcome contributions from the community.
 
 # Communication
 - Before starting to work on a new feature, reach out to us via GitHub or email
-    <bazel-invocation-analyzer-dev@engflow.com>.
+    <analyzer@engflow.com>.
 - If no [issue](/bazel_invocation_analyzer/issues) exists for a new feature yet, crease an issue.
   Assign yourself to signal that you are actively working on the feature.
 - Small patches and bug fixes do not require prior communication.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Bazel Invocation Analyzer is a library and terminal tool developed by EngFlo
 
 You can get in touch with us
 
-- by sending an email to <bazel-invocation-analyzer-dev@engflow.com>
+- by sending an email to <analyzer@engflow.com>
 - by [creating an issue on GitHub](https://github.com/EngFlow/bazel_invocation_analyzer/issues)
 
 ## Dependencies

--- a/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
+++ b/cli/java/com/engflow/bazel/invocation/analyzer/consoleoutput/ConsoleOutput.java
@@ -63,7 +63,7 @@ public class ConsoleOutput {
   private static final String TAB = "\t";
   private static final String FEEDBACK_OPEN_NEW_ISSUE =
       "https://github.com/EngFlow/bazel_invocation_analyzer/issues";
-  private static final String FEEDBACK_EMAIL_ADDRESS = "bazel-invocation-analyzer-dev@engflow.com";
+  private static final String FEEDBACK_EMAIL_ADDRESS = "analyzer@engflow.com";
 
   private final boolean disableFormatting;
   private final boolean verbose;


### PR DESCRIPTION
This email address is easier to remember than the longer one.