### PR TITLE
[DataProvider] Fix NPE in RemoteCacheMetrics

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetrics.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetrics.java
@@ -4,6 +4,10 @@ import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.google.common.base.Objects;
 import java.time.Duration;
 
+/**
+ * Metrics on remote caching, namely how much time was spent on cache checks, downloading outputs,
+ * uploading outputs, and what percentage of actions were cached remotely.
+ */
 public class RemoteCacheMetrics implements Datum {
 
   private final Duration totalCacheCheck;
@@ -34,7 +38,7 @@ public class RemoteCacheMetrics implements Datum {
 
   @Override
   public String getEmptyReason() {
-    return isEmpty() ? null : "No remote cache operations available.";
+    return isEmpty() ? "No remote cache operations available." : null;
   }
 
   @Override

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProvider.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/** A {@link DataProvider} that supplies data on remote caching. */
 public class RemoteCacheMetricsDataProvider extends DataProvider {
 
   @Override

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsDataProviderTest.java
@@ -58,6 +58,14 @@ public class LocalActionsDataProviderTest extends DataProviderUnitTestBase {
   }
 
   @Test
+  public void extractLocalActionsFromEmptyProfile()
+      throws InvalidProfileException, MissingInputException, DuplicateProviderException,
+          NullDatumException {
+    useProfile(metaData(), trace(mainThread()));
+    expect.about(localActions).that(provider.derive()).isEqualTo(LocalActions.create(List.of()));
+  }
+
+  @Test
   public void extractLocalActionsFromSingleThread()
       throws InvalidProfileException, MissingInputException, DuplicateProviderException,
           NullDatumException {


### PR DESCRIPTION
`RemoteCacheMetrics` throws an NPE when it is empty. This change fixes that bug and adds a test for it. It also restructures `RemoteCacheMetricsDataProviderTest` to use `DataProviderUnitTestBase`, and adds a test to `LocalActionsDataProviderTest` for the empty case.

Follow-up to #88.
Bug observed in https://github.com/EngFlow/engflow/pull/13483