### PR TITLE
[infra] Hermetic java linting

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,7 @@ http_archive(
     name = "bazel_skylib",
     sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
     urls = [
+        "https://storage.googleapis.com/engflow-tools-public/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
     ],
@@ -123,42 +124,60 @@ http_file(
     name = "buildifier_darwin_amd64",
     executable = True,
     sha256 = "c9378d9f4293fc38ec54a08fbc74e7a9d28914dae6891334401e59f38f6e65dc",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-amd64"],
+    urls = [
+        "https://storage.googleapis.com/engflow-tools-public/github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-amd64",
+        "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-amd64",
+    ],
 )
 
 http_file(
     name = "buildifier_darwin_arm64",
     executable = True,
     sha256 = "745feb5ea96cb6ff39a76b2821c57591fd70b528325562486d47b5d08900e2e4",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-arm64"],
+    urls = [
+        "https://storage.googleapis.com/engflow-tools-public/github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-arm64",
+        "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-darwin-arm64",
+    ],
 )
 
 http_file(
     name = "buildifier_linux_amd64",
     executable = True,
     sha256 = "52bf6b102cb4f88464e197caac06d69793fa2b05f5ad50a7e7bf6fbd656648a3",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64"],
+    urls = [
+        "https://storage.googleapis.com/engflow-tools-public/github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64",
+        "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64",
+    ],
 )
 
 http_file(
     name = "buildifier_linux_arm64",
     executable = True,
     sha256 = "917d599dbb040e63ae7a7e1adb710d2057811902fdc9e35cce925ebfd966eeb8",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-arm64"],
+    urls = [
+        "https://storage.googleapis.com/engflow-tools-public/github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-arm64",
+        "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-arm64",
+    ],
 )
 
 http_file(
     name = "buildifier_windows_amd64",
     executable = True,
     sha256 = "2f039125e2fbef4c804e43dc11c71866cf444306ac6d0f5e38c592854458f425",
-    urls = ["https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-windows-amd64.exe"],
+    urls = [
+        "https://storage.googleapis.com/engflow-tools-public/github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-windows-amd64.exe",
+        "https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-windows-amd64.exe",
+    ],
 )
 
 ## Java files
 http_jar(
     name = "google_java_format",
     sha256 = "82819a2c5f7067712e0233661b864c1c034f6657d63b8e718b4a50e39ab028f6",
-    url = "https://github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar",
+    urls = [
+        "https://storage.googleapis.com/engflow-tools-public/github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar",
+        "https://github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar",
+    ],
 )
 
 ## Select right platform for buildifier src

--- a/infra/BUILD
+++ b/infra/BUILD
@@ -3,7 +3,7 @@ sh_binary(
     srcs = [":lint.sh"],
     data = [
         "//third_party/buildifier",
-        "@google_java_format//jar",
+        "//third_party/google-java-format",
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/infra/lint.sh
+++ b/infra/lint.sh
@@ -47,8 +47,8 @@ Examples:
 EOT
 }
 
-JAVA_FORMATTER="$(rlocation com_engflow_bazel_invocation_analyzer/third_party/google-java-format/google-java-format)"
-STARLARK_FORMATTER="$(rlocation com_engflow_bazel_invocation_analyzer/third_party/buildifier/buildifier.exe)"
+JAVA_FORMATTER="$(pwd)/third_party/google-java-format/google-java-format"
+STARLARK_FORMATTER="$(pwd)/third_party/buildifier/buildifier.exe"
 POSITIONAL_ARGS=()
 FIX=
 

--- a/infra/lint.sh
+++ b/infra/lint.sh
@@ -47,7 +47,7 @@ Examples:
 EOT
 }
 
-JAVA_FORMATTER="$(rlocation google_java_format/jar/downloaded.jar)"
+JAVA_FORMATTER="$(rlocation com_engflow_bazel_invocation_analyzer/third_party/google-java-format/google-java-format)"
 STARLARK_FORMATTER="$(rlocation com_engflow_bazel_invocation_analyzer/third_party/buildifier/buildifier.exe)"
 POSITIONAL_ARGS=()
 FIX=
@@ -62,7 +62,7 @@ while [[ $# -gt 0 ]]; do
     help
     exit 0
     ;;
-  -* | --*)
+  -*)
     echo >&2 "Unknown option $1"
     help >&2
     exit 1
@@ -82,12 +82,12 @@ function java_files() {
 
 function lint_java() {
   readonly files="$(java_files "${1}")"
-  java -jar "${JAVA_FORMATTER}" --dry-run ${files}
+  "${JAVA_FORMATTER}" --dry-run ${files}
 }
 
 function format_java() {
   readonly files="$(java_files "${1}")"
-  java -jar "${JAVA_FORMATTER}" --replace ${files}
+  "${JAVA_FORMATTER}" --replace ${files}
 }
 
 function lint_starlark() {

--- a/infra/lint.sh
+++ b/infra/lint.sh
@@ -47,6 +47,8 @@ Examples:
 EOT
 }
 
+# rlocation returns the wrong path (does not exist), and `bazel run` runs this
+# tool in a runfiles directory, so we use pwd instead.
 JAVA_FORMATTER="$(pwd)/third_party/google-java-format/google-java-format"
 STARLARK_FORMATTER="$(pwd)/third_party/buildifier/buildifier.exe"
 POSITIONAL_ARGS=()

--- a/third_party/google-java-format/BUILD
+++ b/third_party/google-java-format/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//infra:__subpackages__"])
+
+java_binary(
+    name = "google-java-format",
+    jvm_flags = [
+        "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+    ],
+    main_class = "com.google.googlejavaformat.java.Main",
+    runtime_deps = ["@google_java_format//jar"],
+)


### PR DESCRIPTION
Right now, we are linting our Java files in a non-hermetic way. This change creates a `java_binary` that is run instead of using `java -jar` in the lint script.

Also see https://github.com/EngFlow/website/pull/284