### PR TITLE
[GarbageCollection] Do not fail on missing GC thread.

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStatsDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStatsDataProvider.java
@@ -42,7 +42,8 @@ public class GarbageCollectionStatsDataProvider extends DataProvider {
     BazelProfile bazelProfile = getDataManager().getDatum(BazelProfile.class);
     Optional<ProfileThread> garbageCollectorThread = bazelProfile.getGarbageCollectorThread();
     if (garbageCollectorThread.isEmpty()) {
-      throw new InvalidProfileException("Unable to find garbage collector thread.");
+      return new GarbageCollectionStats(
+          "Failed to find a garbage collector thread in the Bazel profile.");
     }
     Duration majorGarbageCollection =
         garbageCollectorThread.get().getCompleteEvents().stream()

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStatsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStatsDataProviderTest.java
@@ -22,11 +22,9 @@ import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
 import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
-import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
 import com.engflow.bazel.invocation.analyzer.time.TimeUtil;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
@@ -66,8 +64,9 @@ public class GarbageCollectionStatsDataProviderTest extends DataProviderUnitTest
                                 singleGcDuration))))));
 
     GarbageCollectionStats gcStats = provider.getGarbageCollectionStats();
+    assertThat(gcStats.isEmpty()).isFalse();
     assertThat(gcStats.hasMajorGarbageCollection()).isTrue();
-    assertThat(gcStats.getMajorGarbageCollectionDuration())
+    assertThat(gcStats.getMajorGarbageCollectionDuration().get())
         .isEqualTo(singleGcDuration.multipliedBy(4));
   }
 
@@ -93,14 +92,18 @@ public class GarbageCollectionStatsDataProviderTest extends DataProviderUnitTest
                                 singleGcDuration))))));
 
     GarbageCollectionStats gcStats = provider.getGarbageCollectionStats();
+    assertThat(gcStats.isEmpty()).isFalse();
     assertThat(gcStats.hasMajorGarbageCollection()).isFalse();
-    assertThat(gcStats.getMajorGarbageCollectionDuration()).isEqualTo(Duration.ZERO);
+    assertThat(gcStats.getMajorGarbageCollectionDuration().get()).isEqualTo(Duration.ZERO);
   }
 
   @Test
-  public void shouldThrowWhenNoMajorGarbageCollectorThreadIsPresent() throws Exception {
+  public void shouldReturnEmptyGarbageCollectionStatsWhenNoGarbageCollectorThreadIsPresent()
+      throws Exception {
     useProfile(metaData(), trace(mainThread()));
 
-    assertThrows(InvalidProfileException.class, () -> provider.getGarbageCollectionStats());
+    GarbageCollectionStats gcStats = provider.getGarbageCollectionStats();
+    assertThat(gcStats.isEmpty()).isTrue();
+    assertThat(gcStats.hasMajorGarbageCollection()).isFalse();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/GarbageCollectionSuggestionProviderTest.java
@@ -50,8 +50,9 @@ public class GarbageCollectionSuggestionProviderTest extends SuggestionProviderU
   }
 
   @Test
-  public void shouldNotReturnSuggestionForEmptyTotalDuration() {
-    totalDuration = new TotalDuration("empty");
+  public void shouldNotReturnSuggestionForEmptyGarbageCollectionStats() {
+    String emptyReason = "The GC stats are empty!";
+    garbageCollectionStats = new GarbageCollectionStats(emptyReason);
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
 
@@ -62,7 +63,24 @@ public class GarbageCollectionSuggestionProviderTest extends SuggestionProviderU
     assertThat(suggestionOutput.getCaveatList()).hasSize(1);
     assertThat(suggestionOutput.getCaveat(0).getMessage())
         .contains(GarbageCollectionSuggestionProvider.EMPTY_REASON_PREFIX);
-    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains("empty");
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(emptyReason);
+  }
+
+  @Test
+  public void shouldNotReturnSuggestionForEmptyTotalDuration() {
+    String emptyReason = "The total duration is empty!";
+    totalDuration = new TotalDuration(emptyReason);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(GarbageCollectionSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getCaveatList()).hasSize(1);
+    assertThat(suggestionOutput.getCaveat(0).getMessage())
+        .contains(GarbageCollectionSuggestionProvider.EMPTY_REASON_PREFIX);
+    assertThat(suggestionOutput.getCaveat(0).getMessage()).contains(emptyReason);
   }
 
   @Test
@@ -101,7 +119,7 @@ public class GarbageCollectionSuggestionProviderTest extends SuggestionProviderU
                 Locale.US,
                 "%s or %.2f%% of the invocation is spent on major garbage collection",
                 DurationUtil.formatDuration(
-                    garbageCollectionStats.getMajorGarbageCollectionDuration()),
+                    garbageCollectionStats.getMajorGarbageCollectionDuration().get()),
                 percent));
 
     Suggestion rules = suggestionOutput.getSuggestionList().get(1);


### PR DESCRIPTION
Currently, a Bazel profile with no GC threads is identified as invalid. However, in some cases valid Bazel profiles may not include any garbace collection events.
With this PR we no longer throw an error if no GC is found, but rather emit a warning that no GC analysis could be performed.

Contributes ton #110.