### PR TITLE
[BazelProfile] Support reading action count of Bazel profiles generated with Bazel 7

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
@@ -26,4 +26,7 @@ java_library(
     name = "types",
     srcs = TYPES,
     visibility = ["//visibility:public"],
+    deps = [
+        "//third_party/jsr305",
+    ],
 )

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
@@ -13,6 +13,7 @@ java_library(
     deps = [
         ":types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/core",
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders:types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",
         "//third_party/gson",

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
@@ -19,6 +19,7 @@ import com.engflow.bazel.invocation.analyzer.core.DataProvider;
 import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.core.DatumSupplierSpecification;
 import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
+import com.engflow.bazel.invocation.analyzer.dataproviders.BazelVersion;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import com.engflow.bazel.invocation.analyzer.traceeventformat.CounterEvent;
 import com.engflow.bazel.invocation.analyzer.traceeventformat.TraceEventFormatConstants;
@@ -204,6 +205,18 @@ public class BazelProfile implements Datum {
     return ImmutableMap.copyOf(otherData);
   }
 
+  /**
+   * For performance reasons, prefer getting the Datum {@link BazelVersion} provided by {@link
+   * com.engflow.bazel.invocation.analyzer.dataproviders.BazelVersionDataProvider}, which memoizes
+   * the value.
+   *
+   * @return the BazelVersion included in the profile, if any.
+   */
+  public BazelVersion getBazelVersion() {
+    String bazelVersion = getOtherData().get(BazelProfileConstants.OTHER_DATA_BAZEL_VERSION);
+    return BazelVersion.parse(bazelVersion);
+  }
+
   public Stream<ProfileThread> getThreads() {
     return threads.values().stream();
   }
@@ -307,7 +320,9 @@ public class BazelProfile implements Datum {
   @Override
   public String getSummary() {
     StringBuilder sb = new StringBuilder();
-    sb.append("Threads:\n");
+    sb.append("Bazel version:\n");
+    sb.append(getBazelVersion().toString());
+    sb.append("\n\nThreads:\n");
     appendThreadSummary(sb, getMainThread());
     Optional<ProfileThread> optionalCriticalPath = getCriticalPath();
     if (optionalCriticalPath.isPresent()) {

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
@@ -30,10 +30,17 @@ public class BazelProfileConstants {
 
   // CounterEvent names
   // These constants should not be used outside this package.
+
+  // See
+  // https://github.com/bazelbuild/bazel/blob/01f620599c6138de4b4551da92917148ab18efe3/src/main/java/com/google/devtools/build/lib/profiler/ProfilerTask.java#L69
   @VisibleForTesting public static final String COUNTER_ACTION_COUNT = "action count";
   // See
   // https://github.com/bazelbuild/bazel/commit/ec2eda1b56a5197ee2d019f58d89a68b17974b13#diff-f8db96cce91c612e82faa11be7a835199fd31777cf6bf7ce39a069e140a199b2
   static final String COUNTER_ACTION_COUNT_OLD = "action counters";
+
+  // See
+  // https://github.com/bazelbuild/bazel/blob/01f620599c6138de4b4551da92917148ab18efe3/src/main/java/com/google/devtools/build/lib/profiler/CounterSeriesTraceData.java#L92
+  @VisibleForTesting public static final String COUNTER_ACTION_COUNT_TYPE_ACTION = "action";
 
   // Category names
   public static final String CAT_ACTION_PROCESSING = "action processing";

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ThreadId.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ThreadId.java
@@ -15,17 +15,18 @@
 package com.engflow.bazel.invocation.analyzer.bazelprofile;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 public class ThreadId {
   private final int processId;
-  private final int threadId;
+  private final Integer threadId;
 
-  public ThreadId(int processId, int threadId) {
+  public ThreadId(int processId, @Nullable Integer threadId) {
     this.processId = processId;
     this.threadId = threadId;
   }
 
-  public int getThreadId() {
+  public Integer getThreadId() {
     return threadId;
   }
 
@@ -42,7 +43,7 @@ public class ThreadId {
       return false;
     }
     ThreadId other = (ThreadId) o;
-    return processId == other.processId && threadId == other.threadId;
+    return processId == other.processId && Objects.equals(threadId, other.threadId);
   }
 
   @Override

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
@@ -2,6 +2,7 @@ TYPES = [
     "ActionStats.java",
     "BazelPhaseDescription.java",
     "BazelPhaseDescriptions.java",
+    "BazelVersion.java",
     "Bottleneck.java",
     "CriticalPathDuration.java",
     "EstimatedCores.java",

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelVersionDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BazelVersionDataProvider.java
@@ -17,30 +17,18 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 import static com.engflow.bazel.invocation.analyzer.core.DatumSupplier.memoized;
 
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfile;
-import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
 import com.engflow.bazel.invocation.analyzer.core.DataProvider;
 import com.engflow.bazel.invocation.analyzer.core.DatumSupplierSpecification;
 import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
 import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
 import com.engflow.bazel.invocation.analyzer.core.NullDatumException;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * A {@link DataProvider} that supplies data on the Bazel version used when the Bazel profile was
  * generated.
  */
 public class BazelVersionDataProvider extends DataProvider {
-  // See https://bazel.build/release#bazel-versioning
-  // See
-  // https://github.com/bazelbuild/bazel/blob/aab19f75cd383c4b09a6ae720f9fa436bf89d271/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java#L179
-  // See
-  // https://github.com/bazelbuild/bazel/blob/c637041ec145e0964982a2cbf8d5693f0d1d4be0/src/main/java/com/google/devtools/build/lib/analysis/BlazeVersionInfo.java#L119
-  private static final Pattern BAZEL_VERSION_PATTERN =
-      Pattern.compile("^release (\\d+)\\.(\\d+)\\.(\\d+)(|-.*)$");
-
   @Override
   public List<DatumSupplierSpecification<?>> getSuppliers() {
     return List.of(
@@ -49,30 +37,6 @@ public class BazelVersionDataProvider extends DataProvider {
 
   public BazelVersion getBazelVersion()
       throws InvalidProfileException, MissingInputException, NullDatumException {
-    BazelProfile bazelProfile = getDataManager().getDatum(BazelProfile.class);
-    String bazelVersion =
-        bazelProfile.getOtherData().get(BazelProfileConstants.OTHER_DATA_BAZEL_VERSION);
-    return parse(bazelVersion);
-  }
-
-  @VisibleForTesting
-  static BazelVersion parse(String version) {
-    if (version == null) {
-      // The version metadata was introduced in https://github.com/bazelbuild/bazel/pull/17562 and
-      // added to release 6.1.0.
-      return new BazelVersion(
-          "No Bazel version was found. Bazel versions before 6.1.0 did not report the version.");
-    }
-    Matcher m = BAZEL_VERSION_PATTERN.matcher(version);
-    if (m.matches()) {
-      return new BazelVersion(
-          Integer.valueOf(m.group(1)),
-          Integer.valueOf(m.group(2)),
-          Integer.valueOf(m.group(3)),
-          m.group(4));
-    } else {
-      return new BazelVersion(
-          String.format("The provided Bazel version could not be parsed: '%s'", version));
-    }
+    return getDataManager().getDatum(BazelProfile.class).getBazelVersion();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
@@ -7,6 +7,7 @@ java_test(
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile:types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/core",
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders:types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",
         "//analyzer/javatests/com/engflow/bazel/invocation/analyzer:test_base",

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
@@ -12,6 +12,7 @@ java_test(
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",
         "//analyzer/javatests/com/engflow/bazel/invocation/analyzer:test_base",
         "//third_party/guava",
+        "//third_party/jsr305",
         "//third_party/junit",
         "//third_party/truth",
     ],

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/ActionStatsDataProviderTest.java
@@ -17,7 +17,6 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.concat;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.count;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
@@ -48,34 +47,13 @@ public class ActionStatsDataProviderTest extends DataProviderUnitTestBase {
   }
 
   @Test
-  public void shouldReturnEmptyOnEmptyProfile()
-      throws DuplicateProviderException,
-          InvalidProfileException,
-          MissingInputException,
-          NullDatumException {
-    useEstimatedCoresUsed(4);
-    useProfile(metaData(), trace(mainThread()));
-
-    assertThat(provider.getActionStats().getBottlenecks().isEmpty()).isTrue();
-  }
-
-  @Test
   public void shouldReturnEmptyOnEmptyEstimatedCoresUsed()
       throws DuplicateProviderException,
           InvalidProfileException,
           MissingInputException,
           NullDatumException {
+    useMinimalProfile();
     useEstimatedCoresUsed(null);
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                0,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                sequence(
-                    IntStream.rangeClosed(0, 100).boxed(),
-                    ts -> count(BazelProfileConstants.COUNTER_ACTION_COUNT, ts, "action", "4")))));
 
     assertThat(provider.getActionStats().getBottlenecks().isEmpty()).isTrue();
   }
@@ -105,15 +83,28 @@ public class ActionStatsDataProviderTest extends DataProviderUnitTestBase {
                                 TimeUtil.getDurationForMicros(80))),
                     sequence(
                         IntStream.rangeClosed(0, 100).boxed(),
-                        ts -> count(BazelProfileConstants.COUNTER_ACTION_COUNT, ts, "action", "4")),
+                        ts ->
+                            count(
+                                BazelProfileConstants.COUNTER_ACTION_COUNT,
+                                ts,
+                                BazelProfileConstants.COUNTER_ACTION_COUNT_TYPE_ACTION,
+                                "4")),
                     sequence(
                         IntStream.rangeClosed(100, 200).boxed(),
-                        ts -> count(BazelProfileConstants.COUNTER_ACTION_COUNT, ts, "action", "1")),
+                        ts ->
+                            count(
+                                BazelProfileConstants.COUNTER_ACTION_COUNT,
+                                ts,
+                                BazelProfileConstants.COUNTER_ACTION_COUNT_TYPE_ACTION,
+                                "1")),
                     sequence(
                         IntStream.rangeClosed(200, 300).boxed(),
                         ts ->
                             count(
-                                BazelProfileConstants.COUNTER_ACTION_COUNT, ts, "action", "4"))))));
+                                BazelProfileConstants.COUNTER_ACTION_COUNT,
+                                ts,
+                                BazelProfileConstants.COUNTER_ACTION_COUNT_TYPE_ACTION,
+                                "4"))))));
 
     final var actionStats = provider.getActionStats();
 
@@ -162,7 +153,10 @@ public class ActionStatsDataProviderTest extends DataProviderUnitTestBase {
                         IntStream.rangeClosed(0, 300).boxed(),
                         ts ->
                             count(
-                                BazelProfileConstants.COUNTER_ACTION_COUNT, ts, "action", "4"))))));
+                                BazelProfileConstants.COUNTER_ACTION_COUNT,
+                                ts,
+                                BazelProfileConstants.COUNTER_ACTION_COUNT_TYPE_ACTION,
+                                "4"))))));
 
     final var actionStats = provider.getActionStats();
 

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhasesDataProviderTest.java
@@ -14,9 +14,6 @@
 
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -25,6 +22,8 @@ import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfilePhase;
 import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
 import com.engflow.bazel.invocation.analyzer.time.TimeUtil;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,22 +48,18 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void getBazelPhaseDescriptionsShouldWorkWhenAllPhasesArePresent() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        List.of(
+            createPhaseEvents(
+                LAUNCH_START,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                FINISH_TIME)),
+        List.of());
 
     BazelPhaseDescriptions descriptions = provider.getBazelPhaseDescriptions();
     assertThat(descriptions.get(BazelProfilePhase.LAUNCH).get())
@@ -99,22 +94,11 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void getBazelPhaseDescriptionsShouldWorkWhenSomePhasesAreMissing() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    null,
-                    null,
-                    PREP_START,
-                    null,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(
+                LAUNCH_START, INIT_START, null, null, PREP_START, null, FINISH_START, FINISH_TIME)),
+        List.of());
 
     BazelPhaseDescriptions descriptions = provider.getBazelPhaseDescriptions();
     assertThat(descriptions.get(BazelProfilePhase.LAUNCH).get())
@@ -138,14 +122,10 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
   @Test
   public void getBazelPhaseDescriptionsShouldWorkWhenAllButLaunchAndFinishPhaseAreMissing()
       throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(LAUNCH_START, null, null, null, null, null, null, FINISH_TIME))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(LAUNCH_START, null, null, null, null, null, null, FINISH_TIME)),
+        List.of());
 
     BazelPhaseDescriptions descriptions = provider.getBazelPhaseDescriptions();
     assertThat(descriptions.get(BazelProfilePhase.FINISH).get())
@@ -157,22 +137,18 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
   @Test
   public void getBazelPhaseDescriptionsShouldThrowWhenTwoMarkersHaveTheSameTimestamp()
       throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    DEP_START,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(
+                LAUNCH_START,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                DEP_START,
+                FINISH_START,
+                FINISH_TIME)),
+        List.of());
 
     InvalidProfileException invalidProfileException =
         assertThrows(InvalidProfileException.class, () -> provider.getBazelPhaseDescriptions());
@@ -187,22 +163,18 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void getBazelPhaseDescriptionsShouldThrowWhenLaunchPhaseIsMissing() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    null,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(
+                null,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                FINISH_TIME)),
+        List.of());
 
     InvalidProfileException invalidProfileException =
         assertThrows(InvalidProfileException.class, () -> provider.getBazelPhaseDescriptions());
@@ -211,22 +183,18 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void getBazelPhaseDescriptionsShouldThrowWhenFinishPhaseIsMissing() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    null))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(
+                LAUNCH_START,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                null)),
+        List.of());
 
     InvalidProfileException invalidProfileException =
         assertThrows(InvalidProfileException.class, () -> provider.getBazelPhaseDescriptions());
@@ -237,22 +205,18 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void getTotalDurationShouldWorkWhenAllPhasesArePresent() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(
+                LAUNCH_START,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                FINISH_TIME)),
+        List.of());
 
     TotalDuration duration = provider.getTotalDuration();
     assertThat(duration.getTotalDuration().isPresent()).isTrue();
@@ -263,14 +227,10 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
   @Test
   public void getTotalDurationShouldWorkWhenAllButLaunchAndFinishPhaseAreMissing()
       throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(LAUNCH_START, null, null, null, null, null, null, FINISH_TIME))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(LAUNCH_START, null, null, null, null, null, null, FINISH_TIME)),
+        List.of());
 
     TotalDuration duration = provider.getTotalDuration();
     assertThat(duration.getTotalDuration().isPresent()).isTrue();
@@ -280,22 +240,18 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void getTotalDurationShouldThrowWhenLaunchPhasesIsMissing() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    null,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(
+                null,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                FINISH_TIME)),
+        List.of());
 
     InvalidProfileException invalidProfileException =
         assertThrows(InvalidProfileException.class, () -> provider.getTotalDuration());
@@ -304,22 +260,18 @@ public class BazelPhasesDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void getTotalDurationShouldThrowWhenFinishingPhaseIsMissing() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    null))));
+    useProfileWithDefaults(
+        Arrays.asList(
+            createPhaseEvents(
+                LAUNCH_START,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                null)),
+        List.of());
 
     InvalidProfileException invalidProfileException =
         assertThrows(InvalidProfileException.class, () -> provider.getTotalDuration());

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelVersionDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelVersionDataProviderTest.java
@@ -97,22 +97,4 @@ public class BazelVersionDataProviderTest extends DataProviderUnitTestBase {
     assertThat(version.isEmpty()).isFalse();
     assertThat(version.getSummary()).isEqualTo(validBazelVersion);
   }
-
-  @Test
-  public void parseReturnsEmpty() {
-    assertThat(BazelVersionDataProvider.parse("").isEmpty()).isTrue();
-    assertThat(BazelVersionDataProvider.parse("1.2.3").isEmpty()).isTrue();
-    assertThat(BazelVersionDataProvider.parse("1.2.3-foo").isEmpty()).isTrue();
-    assertThat(BazelVersionDataProvider.parse("release 1").isEmpty()).isTrue();
-    assertThat(BazelVersionDataProvider.parse("release 1.2").isEmpty()).isTrue();
-    assertThat(BazelVersionDataProvider.parse("release 1.2.3foo").isEmpty()).isTrue();
-  }
-
-  @Test
-  public void parseReturnsNonempty() {
-    assertThat(BazelVersionDataProvider.parse("release 1.23.4"))
-        .isEqualTo(new BazelVersion(1, 23, 4, ""));
-    assertThat(BazelVersionDataProvider.parse("release 12.3.45-foo"))
-        .isEqualTo(new BazelVersion(12, 3, 45, "-foo"));
-  }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelVersionDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelVersionDataProviderTest.java
@@ -14,14 +14,11 @@
 
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import com.engflow.bazel.invocation.analyzer.WriteBazelProfile;
-import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
-import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
+import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfile;
 import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
 import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
 import com.engflow.bazel.invocation.analyzer.core.NullDatumException;
@@ -39,62 +36,14 @@ public class BazelVersionDataProviderTest extends DataProviderUnitTestBase {
   }
 
   @Test
-  public void shouldReturnEmptyOnMissingBazelVersion()
-      throws DuplicateProviderException,
-          InvalidProfileException,
-          MissingInputException,
-          NullDatumException {
-    useProfile(metaData(), trace(mainThread()));
-    assertThat(provider.getBazelVersion().isEmpty()).isTrue();
-  }
+  public void shouldReturnBazelVersionFromBazelProfile()
+      throws InvalidProfileException, MissingInputException, NullDatumException {
+    BazelVersion expected = BazelVersion.parse("release 1.2.3");
 
-  @Test
-  public void shouldReturnEmptyOnInvalidBazelVersion()
-      throws DuplicateProviderException,
-          InvalidProfileException,
-          MissingInputException,
-          NullDatumException {
-    useProfile(
-        metaData(
-            WriteBazelProfile.Property.put(
-                BazelProfileConstants.OTHER_DATA_BAZEL_VERSION, "invalid")),
-        trace(mainThread()));
-    assertThat(provider.getBazelVersion().isEmpty()).isTrue();
-  }
+    BazelProfile mockProfile = mock(BazelProfile.class);
+    when(dataManager.getDatum(BazelProfile.class)).thenReturn(mockProfile);
+    when(mockProfile.getBazelVersion()).thenReturn(expected);
 
-  @Test
-  public void shouldReturnVersionWithoutPreRelease()
-      throws DuplicateProviderException,
-          InvalidProfileException,
-          MissingInputException,
-          NullDatumException {
-    String validBazelVersion = "release 6.1.0";
-    useProfile(
-        metaData(
-            WriteBazelProfile.Property.put(
-                BazelProfileConstants.OTHER_DATA_BAZEL_VERSION, validBazelVersion)),
-        trace(mainThread()));
-
-    BazelVersion version = provider.getBazelVersion();
-    assertThat(version.isEmpty()).isFalse();
-    assertThat(version.getSummary()).isEqualTo(validBazelVersion);
-  }
-
-  @Test
-  public void shouldReturnBazelVersionWithPreRelease()
-      throws DuplicateProviderException,
-          InvalidProfileException,
-          MissingInputException,
-          NullDatumException {
-    String validBazelVersion = "release 8.0.0-pre.20231030.2";
-    useProfile(
-        metaData(
-            WriteBazelProfile.Property.put(
-                BazelProfileConstants.OTHER_DATA_BAZEL_VERSION, validBazelVersion)),
-        trace(mainThread()));
-
-    BazelVersion version = provider.getBazelVersion();
-    assertThat(version.isEmpty()).isFalse();
-    assertThat(version.getSummary()).isEqualTo(validBazelVersion);
+    assertThat(provider.getBazelVersion()).isEqualTo(expected);
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelVersionTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelVersionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.dataproviders;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public class BazelVersionTest {
+  @Test
+  public void parseReturnsEmpty() {
+    assertThat(BazelVersion.parse("").isEmpty()).isTrue();
+    assertThat(BazelVersion.parse("1.2.3").isEmpty()).isTrue();
+    assertThat(BazelVersion.parse("1.2.3-foo").isEmpty()).isTrue();
+    assertThat(BazelVersion.parse("release 1").isEmpty()).isTrue();
+    assertThat(BazelVersion.parse("release 1.2").isEmpty()).isTrue();
+    assertThat(BazelVersion.parse("release 1.2.3foo").isEmpty()).isTrue();
+  }
+
+  @Test
+  public void parseReturnsNonempty() {
+    assertThat(BazelVersion.parse("release 1.23.4")).isEqualTo(new BazelVersion(1, 23, 4, ""));
+    assertThat(BazelVersion.parse("release 12.3.45-foo"))
+        .isEqualTo(new BazelVersion(12, 3, 45, "-foo"));
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/CriticalPathDurationDataProviderTest.java
@@ -15,17 +15,15 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
 import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,10 +41,9 @@ public class CriticalPathDurationDataProviderTest extends DataProviderUnitTestBa
   @Test
   public void shouldReturnCriticalPathDuration() throws Exception {
     Duration[] durations = {Duration.ofMillis(12), Duration.ofMillis(234), Duration.ofMillis(5)};
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -64,15 +61,15 @@ public class CriticalPathDurationDataProviderTest extends DataProviderUnitTestBa
 
   @Test
   public void shouldBeEmptyWhenCriticalPathIsEmpty() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
     assertThat(provider.getCriticalPathDuration().getCriticalPathDuration().isEmpty()).isTrue();
   }
 
   @Test
   public void shouldBeEmptyWhenCriticalPathHasNoEvents() throws Exception {
-    useProfile(
-        metaData(), trace(mainThread(), thread(0, 0, BazelProfileConstants.THREAD_CRITICAL_PATH)));
+    useProfileWithDefaults(
+        List.of(), List.of(thread(0, 0, BazelProfileConstants.THREAD_CRITICAL_PATH)));
     assertThat(provider.getCriticalPathDuration().getCriticalPathDuration().isEmpty()).isTrue();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/DataProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/DataProvidersTestSuite.java
@@ -22,6 +22,7 @@ import org.junit.runners.Suite;
   ActionStatsDataProviderTest.class,
   BazelPhasesDataProviderTest.class,
   BazelPhaseDescriptionsTest.class,
+  BazelVersionTest.class,
   BazelVersionDataProviderTest.class,
   BazelProfilePhaseTest.class,
   CriticalPathDurationDataProviderTest.class,

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
@@ -15,10 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +25,7 @@ import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import com.google.common.collect.Sets;
 import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,10 +53,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp start = Timestamp.ofMicros(20_000);
     Timestamp within = Timestamp.ofMicros(22_000);
     Timestamp end = Timestamp.ofMicros(30_000);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(0, start, Duration.ZERO),
             skyFrameThread(1, end, Duration.ZERO),
             skyFrameThread(2, within, Duration.ZERO),
@@ -83,10 +80,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp within = Timestamp.ofMicros(22_000);
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRange = Timestamp.ofMicros(30_001);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(maxIndexInRelevantPhase - 1, start, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase - 2, within, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase, end, Duration.ZERO),
@@ -111,10 +107,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp within1 = Timestamp.ofMicros(22_000);
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRange = Timestamp.ofMicros(30_001);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
 
@@ -136,10 +131,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp within1 = Timestamp.ofMicros(22_000);
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRange = Timestamp.ofMicros(30_001);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
 
@@ -162,10 +156,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp within2 = Timestamp.ofMicros(28_000);
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRange = Timestamp.ofMicros(30_001);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
 
@@ -187,7 +180,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp within2 = Timestamp.ofMicros(28_000);
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRange = Timestamp.ofMicros(30_001);
-    useProfile(metaData(), trace(mainThread(), skyFrameThread(3, outsideRange, Duration.ZERO)));
+    useProfileWithDefaults(List.of(), List.of(skyFrameThread(3, outsideRange, Duration.ZERO)));
 
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
@@ -204,10 +197,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
   public void shouldReturnEstimatedCoresUsedAllThreadsWithinRange() throws Exception {
     Timestamp start = Timestamp.ofMicros(20_000);
     Timestamp end = Timestamp.ofMicros(30_000);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(0, start, Duration.ZERO),
             skyFrameThread(1, start, Duration.ZERO),
             skyFrameThread(2, start, Duration.ZERO),
@@ -229,10 +221,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp start = Timestamp.ofMicros(20_000);
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRangeAfter = Timestamp.ofMicros(30_001);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(0, outsideRangeAfter, Duration.ZERO),
             skyFrameThread(1, start, Duration.ZERO),
             skyFrameThread(2, start, Duration.ZERO),
@@ -254,10 +245,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp start = Timestamp.ofMicros(20_000);
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRangeAfter = Timestamp.ofMicros(30_001);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(1, outsideRangeBefore, Duration.ZERO),
             skyFrameThread(2, outsideRangeAfter, Duration.ZERO)));
     BazelPhaseDescriptions bazelPhaseDescriptions =
@@ -279,10 +269,9 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp within2 = Timestamp.ofMicros(28_000);
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRangeAfter = Timestamp.ofMicros(30_001);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             skyFrameThread(0, outsideRangeBefore, Duration.ZERO),
             skyFrameThread(1, within2, Duration.ZERO),
             skyFrameThread(2, outsideRangeAfter, Duration.ZERO),

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStatsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/GarbageCollectionStatsDataProviderTest.java
@@ -16,11 +16,8 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.concat;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -30,6 +27,7 @@ import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
 import com.engflow.bazel.invocation.analyzer.time.TimeUtil;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,10 +45,9 @@ public class GarbageCollectionStatsDataProviderTest extends DataProviderUnitTest
   @Test
   public void shouldReturnMajorGarbageCollection() throws Exception {
     Duration singleGcDuration = TimeUtil.getDurationForMicros(10_000);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -74,10 +71,9 @@ public class GarbageCollectionStatsDataProviderTest extends DataProviderUnitTest
   @Test
   public void shouldReturnNoMajorGarbageCollection() throws Exception {
     Duration singleGcDuration = TimeUtil.getDurationForMicros(10_000);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -99,7 +95,7 @@ public class GarbageCollectionStatsDataProviderTest extends DataProviderUnitTest
 
   @Test
   public void shouldThrowWhenNoMajorGarbageCollectorThreadIsPresent() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
     assertThrows(InvalidProfileException.class, () -> provider.getGarbageCollectionStats());
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsDataProviderTest.java
@@ -1,8 +1,5 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_ACTION_CACHE_CHECK;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_OUTPUT_DOWNLOAD;
 
@@ -63,7 +60,7 @@ public class LocalActionsDataProviderTest extends DataProviderUnitTestBase {
           MissingInputException,
           DuplicateProviderException,
           NullDatumException {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
     expect.about(localActions).that(provider.derive()).isEqualTo(LocalActions.create(List.of()));
   }
 
@@ -86,7 +83,7 @@ public class LocalActionsDataProviderTest extends DataProviderUnitTestBase {
                     thread.action("cached", "Work2", 5, 5),
                     List.of(thread.related(5, 2, CAT_REMOTE_ACTION_CACHE_CHECK)))));
 
-    useProfile(metaData(), trace(mainThread(), thread.asEvent()));
+    useProfileWithDefaults(List.of(), List.of(thread.asEvent()));
     expect.about(localActions).that(provider.derive()).isEqualTo(want);
   }
 
@@ -118,7 +115,7 @@ public class LocalActionsDataProviderTest extends DataProviderUnitTestBase {
                     two.action("two cache miss", "Work3", 8, 5),
                     List.of(two.related(8, 2, CAT_REMOTE_ACTION_CACHE_CHECK)))));
 
-    useProfile(metaData(), trace(mainThread(), one.asEvent(), two.asEvent()));
+    useProfileWithDefaults(List.of(), List.of(one.asEvent(), two.asEvent()));
     expect.about(localActions).that(provider.derive()).isEqualTo(want);
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/MergedEventsPresentDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/MergedEventsPresentDataProviderTest.java
@@ -15,14 +15,12 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,10 +36,9 @@ public class MergedEventsPresentDataProviderTest extends DataProviderUnitTestBas
 
   @Test
   public void shouldReturnMergedEventsPresent() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 20,
                 0,
@@ -58,10 +55,9 @@ public class MergedEventsPresentDataProviderTest extends DataProviderUnitTestBas
 
   @Test
   public void shouldReturnMergedEventsNotPresent() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 20,
                 0,

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProviderTest.java
@@ -1,8 +1,5 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_ACTION_CACHE_CHECK;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_EXECUTION_UPLOAD_TIME;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_OUTPUT_DOWNLOAD;
@@ -35,7 +32,7 @@ public class RemoteCacheMetricsDataProviderTest extends DataProviderUnitTestBase
 
   @Test
   public void shouldBeEmptyWhenNoCachingIsIncluded() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
     when(dataManager.getDatum(LocalActions.class)).thenReturn(LocalActions.create(List.of()));
 
     assertThat(provider.derive().isEmpty()).isTrue();
@@ -48,7 +45,7 @@ public class RemoteCacheMetricsDataProviderTest extends DataProviderUnitTestBase
           MissingInputException,
           DuplicateProviderException,
           NullDatumException {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
     var thread = new EventThreadBuilder(1, 1);
     when(dataManager.getDatum(LocalActions.class))

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProviderTest.java
@@ -16,11 +16,8 @@ package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.concat;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.WriteBazelProfile;
@@ -49,10 +46,9 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     List<Integer> microseconds = List.of(1_000, 20_000, 300);
     String evaluatorThreadActionNameFormat = "some random action %d";
     String criticalPathThreadActionNameFormat = "action 'some random action %d'";
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -101,10 +97,9 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     long mod = TimeUtil.getMicros(Timestamp.ACCEPTABLE_DIVERGENCE);
     String evaluatorThreadActionNameFormat = "some random action %d";
     String criticalPathThreadActionNameFormat = "action 'some random action %d'";
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -154,10 +149,9 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     String evaluatorThreadActionName = "a generic action name that is seen more often";
     String criticalPathThreadActionName = String.format("action '%s'", evaluatorThreadActionName);
     Duration expectedQueuingDuration = TimeUtil.getDurationForMicros(7_000);
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -216,10 +210,9 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     long divergence = TimeUtil.getMicros(Timestamp.ACCEPTABLE_DIVERGENCE) + 1;
     String evaluatorThreadActionNameFormat = "some random action %d";
     String criticalPathThreadActionNameFormat = "action 'some random action %d'";
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -267,10 +260,9 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     long divergence = TimeUtil.getMicros(Timestamp.ACCEPTABLE_DIVERGENCE) + 1;
     String evaluatorThreadActionNameFormat = "some random action %d";
     String criticalPathThreadActionNameFormat = "action 'some random action %d'";
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -314,10 +306,9 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
     List<Integer> microseconds = List.of(1_000, 20_000, 300);
     String evaluatorThreadActionNameFormat = "some random action %d";
     String criticalPathThreadActionNameFormat = "action 'some other action %d'";
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -358,8 +349,8 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
 
   @Test
   public void shouldReturnZeroQueuingDurationWhenCriticalPathIsEmpty() throws Exception {
-    useProfile(
-        metaData(), trace(mainThread(), thread(0, 0, BazelProfileConstants.THREAD_CRITICAL_PATH)));
+    useProfileWithDefaults(
+        List.of(), List.of(thread(0, 0, BazelProfileConstants.THREAD_CRITICAL_PATH)));
 
     assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().get())
         .isEqualTo(Duration.ZERO);
@@ -367,7 +358,7 @@ public class CriticalPathQueuingDurationDataProviderTest extends DataProviderUni
 
   @Test
   public void shouldBeEmptyWhenCriticalPathIsMissing() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
     assertThat(provider.getCriticalPathQueuingDuration().getCriticalPathQueuingDuration().isEmpty())
         .isTrue();

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/QueuingObservedDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/QueuingObservedDataProviderTest.java
@@ -15,10 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
@@ -26,6 +23,7 @@ import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.dataproviders.DataProviderUnitTestBase;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,10 +39,9 @@ public class QueuingObservedDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void shouldReturnQueuingObserved() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -60,7 +57,7 @@ public class QueuingObservedDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void shouldReturnQueuingNotObserved() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
     assertThat(provider.getQueuingObserved().isQueuingObserved()).isFalse();
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteCachingUsedDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteCachingUsedDataProviderTest.java
@@ -15,10 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
@@ -26,6 +23,7 @@ import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.dataproviders.DataProviderUnitTestBase;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,10 +39,9 @@ public class RemoteCachingUsedDataProviderTest extends DataProviderUnitTestBase 
 
   @Test
   public void shouldReturnRemoteCachingUsed() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -60,7 +57,7 @@ public class RemoteCachingUsedDataProviderTest extends DataProviderUnitTestBase 
 
   @Test
   public void shouldReturnRemoteCachingNotUsed() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
     assertThat(provider.getRemoteCachingUsed().isRemoteCachingUsed()).isFalse();
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteExecutionUsedDataProviderTest.java
@@ -15,10 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
@@ -26,6 +23,7 @@ import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.dataproviders.DataProviderUnitTestBase;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,10 +39,9 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
 
   @Test
   public void shouldReturnRemoteExecutionUsedOnRemoteActionExecution() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -60,10 +57,9 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
 
   @Test
   public void shouldReturnRemoteExecutionUsedOnRemoteExecutionQueuingTime() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -79,10 +75,9 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
 
   @Test
   public void shouldReturnRemoteExecutionUsedOnRemoteExecutionSetup() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -98,10 +93,9 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
 
   @Test
   public void shouldReturnRemoteExecutionNotUsedOnRemoteExecutionProcessingTime() throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -117,7 +111,7 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
 
   @Test
   public void shouldReturnRemoteExecutionNotUsedForEmptyProfile() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
     assertThat(provider.getRemoteExecutionUsed().isRemoteExecutionUsed()).isFalse();
   }
@@ -125,10 +119,9 @@ public class RemoteExecutionUsedDataProviderTest extends DataProviderUnitTestBas
   @Test
   public void shouldReturnRemoteExecutionNotUsedForProfileWithOnlyRemoteExecutionUploadTime()
       throws Exception {
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteLatencyDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteLatencyDataProviderTest.java
@@ -15,10 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
@@ -26,6 +23,7 @@ import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.dataproviders.DataProviderUnitTestBase;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,10 +41,9 @@ public class RemoteLatencyDataProviderTest extends DataProviderUnitTestBase {
   public void shouldReturnRemoteLatencyWhenCacheCheck() throws Exception {
     var expectedLatencyMillis = 123456;
     var checkRoundTripTimeMillis = expectedLatencyMillis * 2;
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -68,10 +65,9 @@ public class RemoteLatencyDataProviderTest extends DataProviderUnitTestBase {
   public void shouldReturnRemoteLatencyWhenRemoteExecution() throws Exception {
     var expectedLatencyMillis = 543210;
     var executionRoundTripTimeMillis = expectedLatencyMillis * 2;
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -106,10 +102,9 @@ public class RemoteLatencyDataProviderTest extends DataProviderUnitTestBase {
             latencyCheckMillis1,
             Math.min(
                 latencyCheckMillis2, Math.min(latencyExecutionMillis1, latencyExecutionMillis2)));
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -147,7 +142,7 @@ public class RemoteLatencyDataProviderTest extends DataProviderUnitTestBase {
 
   @Test
   public void shouldBeEmptyWhenRemoteActionsMissing() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
     var remoteLatency = provider.getRemoteLatency();
     assertThat(remoteLatency.isEmpty()).isTrue();

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/TotalQueuingDurationDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/TotalQueuingDurationDataProviderTest.java
@@ -15,11 +15,8 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.sequence;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -30,6 +27,7 @@ import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.dataproviders.DataProviderUnitTestBase;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,10 +45,9 @@ public class TotalQueuingDurationDataProviderTest extends DataProviderUnitTestBa
   @Test
   public void shouldReturnNonZeroQueuingDuration() throws Exception {
     Duration[] durations = {Duration.ofMillis(123), Duration.ofMillis(432), Duration.ofMillis(8)};
-    useProfile(
-        metaData(),
-        trace(
-            mainThread(),
+    useProfileWithDefaults(
+        List.of(),
+        List.of(
             thread(
                 0,
                 0,
@@ -71,9 +68,9 @@ public class TotalQueuingDurationDataProviderTest extends DataProviderUnitTestBa
 
   @Test
   public void shouldReturnZeroQueuingDuration() throws Exception {
-    useProfile(metaData(), trace(mainThread()));
+    useMinimalProfile();
 
-    TotalQueuingDuration queuing = provider.getTotalQueuingDuration();
+    provider.getTotalQueuingDuration();
     verify(dataManager).registerProvider(provider);
     verify(dataManager).getDatum(BazelProfile.class);
     verifyNoMoreInteractions(dataManager);

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/integrationtests/NegligiblePhaseSuggestionProviderIntegrationTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/integrationtests/NegligiblePhaseSuggestionProviderIntegrationTest.java
@@ -14,17 +14,14 @@
 
 package com.engflow.bazel.invocation.analyzer.integrationtests;
 
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
-import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
-import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
 import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfilePhase;
 import com.engflow.bazel.invocation.analyzer.dataproviders.BazelPhasesDataProvider;
 import com.engflow.bazel.invocation.analyzer.suggestionproviders.NegligiblePhaseSuggestionProvider;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,22 +47,18 @@ public class NegligiblePhaseSuggestionProviderIntegrationTest extends Integerati
     final Timestamp FINISH_START = Timestamp.ofSeconds(99);
     final Timestamp FINISH_TIME = Timestamp.ofSeconds(100);
 
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        List.of(
+            createPhaseEvents(
+                LAUNCH_START,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                FINISH_TIME)),
+        List.of());
 
     SuggestionOutput output = provider.getSuggestions(dataManager);
 
@@ -87,22 +80,18 @@ public class NegligiblePhaseSuggestionProviderIntegrationTest extends Integerati
     final Timestamp FINISH_START = Timestamp.ofSeconds(70);
     final Timestamp FINISH_TIME = Timestamp.ofSeconds(80);
 
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        List.of(
+            createPhaseEvents(
+                LAUNCH_START,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                FINISH_TIME)),
+        List.of());
 
     SuggestionOutput output = provider.getSuggestions(dataManager);
 
@@ -134,22 +123,18 @@ public class NegligiblePhaseSuggestionProviderIntegrationTest extends Integerati
     final Timestamp FINISH_START = Timestamp.ofMicros(99_000);
     final Timestamp FINISH_TIME = Timestamp.ofMicros(100_000);
 
-    useProfile(
-        metaData(),
-        trace(
-            thread(
-                20,
-                0,
-                BazelProfileConstants.THREAD_MAIN,
-                createPhaseEvents(
-                    LAUNCH_START,
-                    INIT_START,
-                    EVAL_START,
-                    DEP_START,
-                    PREP_START,
-                    EXEC_START,
-                    FINISH_START,
-                    FINISH_TIME))));
+    useProfileWithDefaults(
+        List.of(
+            createPhaseEvents(
+                LAUNCH_START,
+                INIT_START,
+                EVAL_START,
+                DEP_START,
+                PREP_START,
+                EXEC_START,
+                FINISH_START,
+                FINISH_TIME)),
+        List.of());
 
     SuggestionOutput output = provider.getSuggestions(dataManager);
 


### PR DESCRIPTION
With Bazel 7, the action count events are no longer part of the `Main Thread`, as they no longer include a `tid`.
This PR changes the logic, so that the action count can be retrieved both for older styleand newer style profiles.

Contributes to #113.