### PR TITLE
[DataProvider] Add `SkymeldUsed` Datum and provide it

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfilePhase.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfilePhase.java
@@ -17,10 +17,14 @@ package com.engflow.bazel.invocation.analyzer.bazelprofile;
 public enum BazelProfilePhase {
   // The order of these is important, it reflects in which order we expect the timestamps of the
   // phases markers in the Bazel profile to be.
+  // Names taken from
+  // https://github.com/bazelbuild/bazel/blob/febfa54dbe62d719ad6dbbfdd12bd6f8c0923b7a/src/main/java/com/google/devtools/build/lib/profiler/ProfilePhase.java#L20-L32
   LAUNCH("Launch Blaze"),
   INIT("Initialize command"),
-  EVALUATE("Evaluate target patterns"),
-  DEPENDENCIES("Load and analyze dependencies"),
+  TARGET_PATTERN_EVAL("Evaluate target patterns"),
+  ANALYZE("Load and analyze dependencies"),
+  ANALYZE_AND_EXECUTE("Load, analyze dependencies and build artifacts"),
+  LICENSE("Analyze licenses"),
   PREPARE("Prepare for build"),
   EXECUTE("Build artifacts"),
   FINISH("Complete build");

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
@@ -10,6 +10,7 @@ TYPES = [
     "EstimatedJobsFlagValue.java",
     "GarbageCollectionStats.java",
     "MergedEventsPresent.java",
+    "SkymeldUsed.java",
     "TotalDuration.java",
 ]
 

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/DataProviderUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/DataProviderUtil.java
@@ -37,8 +37,9 @@ public class DataProviderUtil {
         new CriticalPathDurationDataProvider(),
         new EstimatedCoresDataProvider(),
         new GarbageCollectionStatsDataProvider(),
-        new MergedEventsPresentDataProvider(),
         new LocalActionsDataProvider(),
+        new MergedEventsPresentDataProvider(),
+        new SkymeldUsedDataProvider(),
 
         // RemoteExecution
         new CriticalPathQueuingDurationDataProvider(),

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProvider.java
@@ -103,7 +103,7 @@ public class EstimatedCoresDataProvider extends DataProvider {
     if (evaluateAndDependenciesPhaseSkyframeEvaluators == null) {
       return new EstimatedJobsFlagValue(ESTIMATED_JOBS_FLAG_VALUE_EMPTY_REASON_EVAL_DEP_MISSING);
     }
-    if (executionPhaseSkyframeEvaluators == null
+    if (executionPhaseSkyframeEvaluatorsMaxValue == null
         || evaluateAndDependenciesPhaseSkyframeEvaluatorsMaxValue == null) {
       return new EstimatedJobsFlagValue(ESTIMATED_JOBS_FLAG_VALUE_EMPTY_REASON_EVENTS_MISSING);
     }
@@ -171,13 +171,13 @@ public class EstimatedCoresDataProvider extends DataProvider {
       // phases. These phases should use as many cores as there are available, irrespective of
       // whether the Bazel flag `--jobs` is set or not.
       Optional<BazelPhaseDescription> start =
-          bazelPhaseDescriptions.has(BazelProfilePhase.EVALUATE)
-              ? bazelPhaseDescriptions.get(BazelProfilePhase.EVALUATE)
-              : bazelPhaseDescriptions.get(BazelProfilePhase.DEPENDENCIES);
+          bazelPhaseDescriptions.has(BazelProfilePhase.TARGET_PATTERN_EVAL)
+              ? bazelPhaseDescriptions.get(BazelProfilePhase.TARGET_PATTERN_EVAL)
+              : bazelPhaseDescriptions.get(BazelProfilePhase.ANALYZE);
       Optional<BazelPhaseDescription> end =
-          bazelPhaseDescriptions.has(BazelProfilePhase.DEPENDENCIES)
-              ? bazelPhaseDescriptions.get(BazelProfilePhase.DEPENDENCIES)
-              : bazelPhaseDescriptions.get(BazelProfilePhase.EVALUATE);
+          bazelPhaseDescriptions.has(BazelProfilePhase.ANALYZE)
+              ? bazelPhaseDescriptions.get(BazelProfilePhase.ANALYZE)
+              : bazelPhaseDescriptions.get(BazelProfilePhase.TARGET_PATTERN_EVAL);
       if (start.isEmpty() || end.isEmpty()) {
         // The profile does not include that data necessary.
         return;

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/SkymeldUsed.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/SkymeldUsed.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.dataproviders;
+
+import com.engflow.bazel.invocation.analyzer.core.Datum;
+
+/**
+ * Whether evidence was found that Skymeld was used.
+ *
+ * @see <a href="https://github.com/bazelbuild/bazel/issues/14057">Project Skymeld GitHub issue</a>
+ */
+public class SkymeldUsed implements Datum {
+  private final boolean skymeldUsed;
+
+  public SkymeldUsed(boolean skymeldUsed) {
+    this.skymeldUsed = skymeldUsed;
+  }
+
+  public boolean isSkymeldUsed() {
+    return skymeldUsed;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Whether the Bazel Profile includes events indicating that Skymeld was used.";
+  }
+
+  @Override
+  public String getSummary() {
+    return String.valueOf(skymeldUsed);
+  }
+}

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/SkymeldUsedDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/SkymeldUsedDataProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.dataproviders;
+
+import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfilePhase;
+import com.engflow.bazel.invocation.analyzer.core.DataProvider;
+import com.engflow.bazel.invocation.analyzer.core.DatumSupplier;
+import com.engflow.bazel.invocation.analyzer.core.DatumSupplierSpecification;
+import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
+import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
+import com.engflow.bazel.invocation.analyzer.core.NullDatumException;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.List;
+
+/**
+ * A {@link DataProvider} that returns whether the profile looks like it was generated while using
+ * Skymeld.
+ *
+ * @see <a href="https://github.com/bazelbuild/bazel/issues/14057">Project Skymeld GitHub issue</a>
+ */
+public class SkymeldUsedDataProvider extends DataProvider {
+
+  @Override
+  public List<DatumSupplierSpecification<?>> getSuppliers() {
+    return List.of(
+        DatumSupplierSpecification.of(
+            SkymeldUsed.class, DatumSupplier.memoized(this::getSkymeldUsed)));
+  }
+
+  @VisibleForTesting
+  SkymeldUsed getSkymeldUsed()
+      throws InvalidProfileException, MissingInputException, NullDatumException {
+    BazelPhaseDescriptions bazelPhaseDescriptions =
+        getDataManager().getDatum(BazelPhaseDescriptions.class);
+    return new SkymeldUsed(
+        bazelPhaseDescriptions.get(BazelProfilePhase.ANALYZE_AND_EXECUTE).isPresent());
+  }
+}

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NegligiblePhaseSuggestionProvider.java
@@ -54,7 +54,10 @@ public class NegligiblePhaseSuggestionProvider extends SuggestionProviderBase {
   @VisibleForTesting
   public static final List<BazelProfilePhase> NON_NEGLIGIBLE_PHASES =
       List.of(
-          BazelProfilePhase.EVALUATE, BazelProfilePhase.DEPENDENCIES, BazelProfilePhase.EXECUTE);
+          BazelProfilePhase.TARGET_PATTERN_EVAL,
+          BazelProfilePhase.ANALYZE,
+          BazelProfilePhase.ANALYZE_AND_EXECUTE,
+          BazelProfilePhase.EXECUTE);
   // Don't apply this check to profiles shorter than this duration
   private static final Duration MIN_DURATION = Duration.ofSeconds(30);
   // Non-negligible phases should be less than this percentage of total duration (1.0 = 1%)

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptionsTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelPhaseDescriptionsTest.java
@@ -26,8 +26,10 @@ public class BazelPhaseDescriptionsTest {
     BazelPhaseDescription description =
         new BazelPhaseDescription(Timestamp.ofMicros(1), Timestamp.ofMicros(2));
     BazelPhaseDescriptions descriptions =
-        BazelPhaseDescriptions.newBuilder().add(BazelProfilePhase.EVALUATE, description).build();
-    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.EVALUATE).get())
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.TARGET_PATTERN_EVAL, description)
+            .build();
+    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.TARGET_PATTERN_EVAL).get())
         .isEqualTo(description);
   }
 
@@ -40,17 +42,18 @@ public class BazelPhaseDescriptionsTest {
     BazelPhaseDescriptions descriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.INIT, otherDescription)
-            .add(BazelProfilePhase.EVALUATE, expectedDescription)
+            .add(BazelProfilePhase.TARGET_PATTERN_EVAL, expectedDescription)
             .add(BazelProfilePhase.PREPARE, otherDescription)
             .build();
-    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.DEPENDENCIES).get())
+    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.ANALYZE).get())
         .isEqualTo(expectedDescription);
   }
 
   @Test
   public void getOrClosestBeforeShouldReturnEmpty() {
     BazelPhaseDescriptions descriptions = BazelPhaseDescriptions.newBuilder().build();
-    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.EVALUATE).isEmpty()).isTrue();
+    assertThat(descriptions.getOrClosestBefore(BazelProfilePhase.TARGET_PATTERN_EVAL).isEmpty())
+        .isTrue();
   }
 
   @Test
@@ -58,8 +61,10 @@ public class BazelPhaseDescriptionsTest {
     BazelPhaseDescription description =
         new BazelPhaseDescription(Timestamp.ofMicros(1), Timestamp.ofMicros(2));
     BazelPhaseDescriptions descriptions =
-        BazelPhaseDescriptions.newBuilder().add(BazelProfilePhase.EVALUATE, description).build();
-    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE).get())
+        BazelPhaseDescriptions.newBuilder()
+            .add(BazelProfilePhase.TARGET_PATTERN_EVAL, description)
+            .build();
+    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.TARGET_PATTERN_EVAL).get())
         .isEqualTo(description);
   }
 
@@ -75,13 +80,14 @@ public class BazelPhaseDescriptionsTest {
             .add(BazelProfilePhase.PREPARE, expectedDescription)
             .add(BazelProfilePhase.EXECUTE, otherDescription)
             .build();
-    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE).get())
+    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.TARGET_PATTERN_EVAL).get())
         .isEqualTo(expectedDescription);
   }
 
   @Test
   public void getOrClosestAfterShouldReturnEmpty() {
     BazelPhaseDescriptions descriptions = BazelPhaseDescriptions.newBuilder().build();
-    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.EVALUATE).isEmpty()).isTrue();
+    assertThat(descriptions.getOrClosestAfter(BazelProfilePhase.TARGET_PATTERN_EVAL).isEmpty())
+        .isTrue();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelProfilePhaseTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/BazelProfilePhaseTest.java
@@ -25,9 +25,15 @@ public class BazelProfilePhaseTest {
   public void getPreviousWorks() {
     assertThat(BazelProfilePhase.FINISH.getPrevious()).isEqualTo(BazelProfilePhase.EXECUTE);
     assertThat(BazelProfilePhase.EXECUTE.getPrevious()).isEqualTo(BazelProfilePhase.PREPARE);
-    assertThat(BazelProfilePhase.PREPARE.getPrevious()).isEqualTo(BazelProfilePhase.DEPENDENCIES);
-    assertThat(BazelProfilePhase.DEPENDENCIES.getPrevious()).isEqualTo(BazelProfilePhase.EVALUATE);
-    assertThat(BazelProfilePhase.EVALUATE.getPrevious()).isEqualTo(BazelProfilePhase.INIT);
+    assertThat(BazelProfilePhase.PREPARE.getPrevious()).isEqualTo(BazelProfilePhase.LICENSE);
+    assertThat(BazelProfilePhase.LICENSE.getPrevious())
+        .isEqualTo(BazelProfilePhase.ANALYZE_AND_EXECUTE);
+    assertThat(BazelProfilePhase.ANALYZE_AND_EXECUTE.getPrevious())
+        .isEqualTo(BazelProfilePhase.ANALYZE);
+    assertThat(BazelProfilePhase.ANALYZE.getPrevious())
+        .isEqualTo(BazelProfilePhase.TARGET_PATTERN_EVAL);
+    assertThat(BazelProfilePhase.TARGET_PATTERN_EVAL.getPrevious())
+        .isEqualTo(BazelProfilePhase.INIT);
     assertThat(BazelProfilePhase.INIT.getPrevious()).isEqualTo(BazelProfilePhase.LAUNCH);
     assertThrows(UnsupportedOperationException.class, () -> BazelProfilePhase.LAUNCH.getPrevious());
   }
@@ -35,9 +41,14 @@ public class BazelProfilePhaseTest {
   @Test
   public void getNextWorks() {
     assertThat(BazelProfilePhase.LAUNCH.getNext()).isEqualTo(BazelProfilePhase.INIT);
-    assertThat(BazelProfilePhase.INIT.getNext()).isEqualTo(BazelProfilePhase.EVALUATE);
-    assertThat(BazelProfilePhase.EVALUATE.getNext()).isEqualTo(BazelProfilePhase.DEPENDENCIES);
-    assertThat(BazelProfilePhase.DEPENDENCIES.getNext()).isEqualTo(BazelProfilePhase.PREPARE);
+    assertThat(BazelProfilePhase.INIT.getNext()).isEqualTo(BazelProfilePhase.TARGET_PATTERN_EVAL);
+    assertThat(BazelProfilePhase.TARGET_PATTERN_EVAL.getNext())
+        .isEqualTo(BazelProfilePhase.ANALYZE);
+    assertThat(BazelProfilePhase.ANALYZE.getNext())
+        .isEqualTo(BazelProfilePhase.ANALYZE_AND_EXECUTE);
+    assertThat(BazelProfilePhase.ANALYZE_AND_EXECUTE.getNext())
+        .isEqualTo(BazelProfilePhase.LICENSE);
+    assertThat(BazelProfilePhase.LICENSE.getNext()).isEqualTo(BazelProfilePhase.PREPARE);
     assertThat(BazelProfilePhase.PREPARE.getNext()).isEqualTo(BazelProfilePhase.EXECUTE);
     assertThat(BazelProfilePhase.EXECUTE.getNext()).isEqualTo(BazelProfilePhase.FINISH);
     assertThrows(UnsupportedOperationException.class, () -> BazelProfilePhase.FINISH.getNext());

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/DataProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/DataProvidersTestSuite.java
@@ -27,8 +27,9 @@ import org.junit.runners.Suite;
   CriticalPathDurationDataProviderTest.class,
   EstimatedCoresDataProviderTest.class,
   GarbageCollectionStatsDataProviderTest.class,
-  MergedEventsPresentDataProviderTest.class,
   LocalActionsDataProviderTest.class,
-  RemoteCacheMetricsDataProviderTest.class
+  MergedEventsPresentDataProviderTest.class,
+  RemoteCacheMetricsDataProviderTest.class,
+  SkymeldUsedDataProviderTest.class
 })
 public class DataProvidersTestSuite {}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
@@ -66,8 +66,8 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
-            .add(BazelProfilePhase.EVALUATE, new BazelPhaseDescription(start, within))
-            .add(BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(within, end))
+            .add(BazelProfilePhase.TARGET_PATTERN_EVAL, new BazelPhaseDescription(start, within))
+            .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(within, end))
             .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
@@ -94,8 +94,8 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
-            .add(BazelProfilePhase.EVALUATE, new BazelPhaseDescription(start, within))
-            .add(BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(within, end))
+            .add(BazelProfilePhase.TARGET_PATTERN_EVAL, new BazelPhaseDescription(start, within))
+            .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(within, end))
             .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
@@ -120,7 +120,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
-            .add(BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(start, end))
+            .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(start, end))
             .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
@@ -145,7 +145,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
-            .add(BazelProfilePhase.EVALUATE, new BazelPhaseDescription(start, end))
+            .add(BazelProfilePhase.TARGET_PATTERN_EVAL, new BazelPhaseDescription(start, end))
             .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
@@ -191,8 +191,8 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
 
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
-            .add(BazelProfilePhase.EVALUATE, new BazelPhaseDescription(start, within1))
-            .add(BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(within2, end))
+            .add(BazelProfilePhase.TARGET_PATTERN_EVAL, new BazelPhaseDescription(start, within1))
+            .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(within2, end))
             .build();
 
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
@@ -289,7 +289,7 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(3, within1, Duration.ZERO)));
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
-            .add(BazelProfilePhase.DEPENDENCIES, new BazelPhaseDescription(start, within1))
+            .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(start, within1))
             .add(BazelProfilePhase.FINISH, new BazelPhaseDescription(within2, end))
             .build();
 

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/SkymeldUsedDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/SkymeldUsedDataProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.dataproviders;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfilePhase;
+import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
+import com.engflow.bazel.invocation.analyzer.time.Timestamp;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SkymeldUsedDataProviderTest extends DataProviderUnitTestBase {
+  private SkymeldUsedDataProvider provider;
+
+  @Before
+  public void setupTest() throws DuplicateProviderException {
+    provider = new SkymeldUsedDataProvider();
+    provider.register(dataManager);
+    super.dataProvider = provider;
+  }
+
+  @Test
+  public void shouldReturnSkymeldNotUsed() throws Exception {
+    when(dataManager.getDatum(BazelPhaseDescriptions.class))
+        .thenReturn(BazelPhaseDescriptions.newBuilder().build());
+    assertThat(provider.getSkymeldUsed().isSkymeldUsed()).isFalse();
+  }
+
+  @Test
+  public void shouldReturnSkymeldUsed() throws Exception {
+    when(dataManager.getDatum(BazelPhaseDescriptions.class))
+        .thenReturn(
+            BazelPhaseDescriptions.newBuilder()
+                .add(
+                    BazelProfilePhase.ANALYZE_AND_EXECUTE,
+                    new BazelPhaseDescription(Timestamp.ofSeconds(2), Timestamp.ofSeconds(3)))
+                .build());
+    assertThat(provider.getSkymeldUsed().isSkymeldUsed()).isTrue();
+  }
+}


### PR DESCRIPTION
As a first step to supporting Bazel profiles where Skymeld was used, add a `Datum` that indices whether the profile looks like it was generated while using Skymeld.

Contributes to #91
Contributes to #97