### PR TITLE
[Skymeld] Adjust `DataProvider`s and `SuggestProvider`s for Skymeld

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresAvailable.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresAvailable.java
@@ -29,7 +29,8 @@ public class EstimatedCoresAvailable extends EstimatedCores {
 
   @Override
   public String getDescription() {
-    return "The estimated number of cores available, as well as how many numbers were skipped"
-        + " when naming skyframe-evaluators. Extracted from the Bazel profile.";
+    return "The estimated number of cores available on the machine that ran the Bazel client, as"
+        + " well as how many numbers were skipped when naming skyframe-evaluators. Extracted"
+        + " from the Bazel profile.";
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresUsed.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresUsed.java
@@ -29,7 +29,7 @@ public class EstimatedCoresUsed extends EstimatedCores {
 
   @Override
   public String getDescription() {
-    return "The estimated number of cores used, as well as how many numbers were skipped when"
-        + " naming skyframe-evaluators. Extracted from the Bazel profile.";
+    return "The estimated number of cores used during execution, as well as how many numbers were"
+        + " skipped when naming skyframe-evaluators. Extracted from the Bazel profile.";
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/EstimatedCoresDataProviderTest.java
@@ -28,11 +28,21 @@ import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import com.google.common.collect.Sets;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
 public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
+  private static SkymeldUsed NO_SKYMELD = new SkymeldUsed();
+  private static SkymeldUsed WITH_SKYMELD_NO_EXECUTION =
+      new SkymeldUsed(
+          new BazelPhaseDescription(Timestamp.ofSeconds(1), Timestamp.ofSeconds(4)),
+          Optional.empty());
+  private static SkymeldUsed WITH_SKYMELD_WITH_EXECUTION =
+      new SkymeldUsed(
+          new BazelPhaseDescription(Timestamp.ofSeconds(1), Timestamp.ofSeconds(4)),
+          Optional.of(Timestamp.ofSeconds(2)));
   private EstimatedCoresDataProvider provider;
 
   @Before
@@ -63,13 +73,12 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(1, end, Duration.ZERO),
             skyFrameThread(2, within, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase, within, Duration.ZERO)));
-
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.TARGET_PATTERN_EVAL, new BazelPhaseDescription(start, within))
             .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(within, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     EstimatedCoresAvailable estimatedCores = provider.getEstimatedCoresAvailable();
@@ -91,13 +100,12 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(maxIndexInRelevantPhase - 2, within, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase, end, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
-
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.TARGET_PATTERN_EVAL, new BazelPhaseDescription(start, within))
             .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(within, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     EstimatedCoresAvailable estimatedCores = provider.getEstimatedCoresAvailable();
@@ -117,12 +125,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             mainThread(),
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
-
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(start, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores().get())
@@ -142,12 +149,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             mainThread(),
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
-
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.TARGET_PATTERN_EVAL, new BazelPhaseDescription(start, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores().get())
@@ -168,13 +174,12 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             mainThread(),
             skyFrameThread(maxIndexInRelevantPhase, within1, Duration.ZERO),
             skyFrameThread(maxIndexInRelevantPhase + 3, outsideRange, Duration.ZERO)));
-
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.INIT, new BazelPhaseDescription(start, within1))
             .add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(within2, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores().isEmpty()).isTrue();
@@ -188,13 +193,12 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
     Timestamp end = Timestamp.ofMicros(30_000);
     Timestamp outsideRange = Timestamp.ofMicros(30_001);
     useProfile(metaData(), trace(mainThread(), skyFrameThread(3, outsideRange, Duration.ZERO)));
-
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.TARGET_PATTERN_EVAL, new BazelPhaseDescription(start, within1))
             .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(within2, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     assertThat(provider.getEstimatedCoresAvailable().getEstimatedCores().isEmpty()).isTrue();
@@ -212,11 +216,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(1, start, Duration.ZERO),
             skyFrameThread(2, start, Duration.ZERO),
             skyFrameThread(3, start, Duration.ZERO)));
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(start, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     EstimatedCoresUsed estimatedCores = provider.getEstimatedCoresUsed();
@@ -237,11 +241,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(1, start, Duration.ZERO),
             skyFrameThread(2, start, Duration.ZERO),
             skyFrameThread(3, outsideRangeBefore, Duration.ZERO)));
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(start, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     EstimatedCoresUsed estimatedCores = provider.getEstimatedCoresUsed();
@@ -260,11 +264,11 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             mainThread(),
             skyFrameThread(1, outsideRangeBefore, Duration.ZERO),
             skyFrameThread(2, outsideRangeAfter, Duration.ZERO)));
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.EXECUTE, new BazelPhaseDescription(start, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     assertThat(provider.getEstimatedCoresUsed().isEmpty()).isTrue();
@@ -287,12 +291,12 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
             skyFrameThread(1, within2, Duration.ZERO),
             skyFrameThread(2, outsideRangeAfter, Duration.ZERO),
             skyFrameThread(3, within1, Duration.ZERO)));
+    when(dataManager.getDatum(SkymeldUsed.class)).thenReturn(NO_SKYMELD);
     BazelPhaseDescriptions bazelPhaseDescriptions =
         BazelPhaseDescriptions.newBuilder()
             .add(BazelProfilePhase.ANALYZE, new BazelPhaseDescription(start, within1))
             .add(BazelProfilePhase.FINISH, new BazelPhaseDescription(within2, end))
             .build();
-
     when(dataManager.getDatum(BazelPhaseDescriptions.class)).thenReturn(bazelPhaseDescriptions);
 
     assertThat(provider.getEstimatedCoresUsed().isEmpty()).isTrue();
@@ -302,41 +306,80 @@ public class EstimatedCoresDataProviderTest extends DataProviderUnitTestBase {
   public void getGapsShouldRecognizeGapsWhenSetIsEmpty() {
     // 0, 1, 2 are missing.
     Set<Integer> values = Sets.newHashSet();
-    assertThat(provider.getGaps(values, 2)).isEqualTo(3);
+    assertThat(EstimatedCoresDataProvider.getGaps(values, 2)).isEqualTo(3);
   }
 
   @Test
   public void getGapsShouldRecognizeNoGaps() {
     // All present.
     Set<Integer> values = Sets.newHashSet(0, 1, 2, 3, 4, 5);
-    assertThat(provider.getGaps(values, 5)).isEqualTo(0);
+    assertThat(EstimatedCoresDataProvider.getGaps(values, 5)).isEqualTo(0);
   }
 
   @Test
   public void getGapsShouldRecognizeGapsInTheStart() {
     // 0 is missing.
     Set<Integer> values = Sets.newHashSet(1, 2, 3, 4, 5);
-    assertThat(provider.getGaps(values, 5)).isEqualTo(1);
+    assertThat(EstimatedCoresDataProvider.getGaps(values, 5)).isEqualTo(1);
   }
 
   @Test
   public void getGapsShouldRecognizeGapsInMiddle() {
     // 1, 2, 4 are missing.
     Set<Integer> values = Sets.newHashSet(0, 3, 5);
-    assertThat(provider.getGaps(values, 5)).isEqualTo(3);
+    assertThat(EstimatedCoresDataProvider.getGaps(values, 5)).isEqualTo(3);
   }
 
   @Test
   public void getGapsShouldRecognizeGapsInTheEnd() {
     // 4, 5 are missing.
     Set<Integer> values = Sets.newHashSet(0, 1, 2, 3);
-    assertThat(provider.getGaps(values, 5)).isEqualTo(2);
+    assertThat(EstimatedCoresDataProvider.getGaps(values, 5)).isEqualTo(2);
   }
 
   @Test
   public void getGapsShouldRecognizeGapsThroughout() {
     // 0, 2, 3, 4, 5 are missing.
     Set<Integer> values = Sets.newHashSet(1);
-    assertThat(provider.getGaps(values, 5)).isEqualTo(5);
+    assertThat(EstimatedCoresDataProvider.getGaps(values, 5)).isEqualTo(5);
+  }
+
+  @Test
+  public void getExecutionPhasePresentWithoutSkymeld() {
+    BazelPhaseDescription executionPhase =
+        new BazelPhaseDescription(Timestamp.ofSeconds(1), Timestamp.ofSeconds(2));
+    BazelPhaseDescriptions phaseDescriptions =
+        BazelPhaseDescriptions.newBuilder().add(BazelProfilePhase.EXECUTE, executionPhase).build();
+
+    var actualPhase = EstimatedCoresDataProvider.getExecutionPhase(NO_SKYMELD, phaseDescriptions);
+    assertThat(actualPhase.isPresent()).isTrue();
+    assertThat(actualPhase.get()).isEqualTo(executionPhase);
+  }
+
+  @Test
+  public void getExecutionPhaseEmptyWithoutSkymeld() {
+    assertThat(
+            EstimatedCoresDataProvider.getExecutionPhase(
+                    NO_SKYMELD, BazelPhaseDescriptions.newBuilder().build())
+                .isEmpty())
+        .isTrue();
+  }
+
+  @Test
+  public void getExecutionPhasePresentWithSkymeld() {
+    var actualPhase =
+        EstimatedCoresDataProvider.getExecutionPhase(
+            WITH_SKYMELD_WITH_EXECUTION, BazelPhaseDescriptions.newBuilder().build());
+    assertThat(actualPhase.isPresent()).isTrue();
+    assertThat(actualPhase).isEqualTo(WITH_SKYMELD_WITH_EXECUTION.getExecutionPhase());
+  }
+
+  @Test
+  public void getExecutionPhaseEmptyWithSkymeld() {
+    assertThat(
+            EstimatedCoresDataProvider.getExecutionPhase(
+                    WITH_SKYMELD_NO_EXECUTION, BazelPhaseDescriptions.newBuilder().build())
+                .isEmpty())
+        .isTrue();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/integrationtests/JobsSuggestionProviderIntegrationTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/integrationtests/JobsSuggestionProviderIntegrationTest.java
@@ -23,6 +23,7 @@ import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedCoresAvailab
 import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedCoresDataProvider;
 import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedCoresUsed;
 import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedJobsFlagValue;
+import com.engflow.bazel.invocation.analyzer.dataproviders.SkymeldUsedDataProvider;
 import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteCachingUsedDataProvider;
 import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteExecutionUsedDataProvider;
 import com.engflow.bazel.invocation.analyzer.suggestionproviders.JobsSuggestionProvider;
@@ -40,6 +41,7 @@ public class JobsSuggestionProviderIntegrationTest extends IntegerationTestBase 
     new EstimatedCoresDataProvider().register(dataManager);
     new RemoteCachingUsedDataProvider().register(dataManager);
     new RemoteExecutionUsedDataProvider().register(dataManager);
+    new SkymeldUsedDataProvider().register(dataManager);
   }
 
   public void withProfile(String filename) throws Exception {


### PR DESCRIPTION
This change adds support for analysing profiles generated when using Skymeld. For this, the interlaced analysis and execution phase is split into two parts:

1. Analysis only, no execution interlaced.
2. Execution has started. analysis and execution may be interlaced.

This is done by checking for the first observed `action processing` event. The distinction is relevant, because it helps us determine how many cores are available on the machine that ran the Bazel client, as well has how many cores are used during execution. The later may be higher than the prior, e.g. when remote execution is used.

* Update `SkymeldUsed` to include the combined analysis and execution phase, as well as optionally the phase at which execution likely starts.
* Update `EstimatedCoresDataProvider` to estimate cores when Skymeld is used.
* Update `CriticalPathNotDominantSuggestionProvider` when Skymeld is used, if the information when execution started is available.

Contributes to #97.