### PR TITLE
[SuggestionProvider] Highlight locally executed actions when remote execution is used

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
@@ -1,4 +1,5 @@
 TYPES = [
+    "BazelProfileConstants.java",
     "BazelProfilePhase.java",
     "ThreadId.java",
 ]
@@ -25,4 +26,7 @@ java_library(
     name = "types",
     srcs = TYPES,
     visibility = ["//visibility:public"],
+    deps = [
+        "//third_party/guava",
+    ],
 )

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
@@ -66,6 +66,8 @@ public class BazelProfileConstants {
   public static final String CAT_CRITICAL_PATH_COMPONENT = "critical path component";
   public static final String CAT_GARBAGE_COLLECTION = "gc notification";
   public static final String CAT_GENERAL_INFORMATION = "general information";
+
+  public static final String CAT_LOCAL_ACTION_EXECUTION = "local action execution";
   public static final String CAT_REMOTE_ACTION_CACHE_CHECK = "remote action cache check";
   public static final String CAT_REMOTE_ACTION_EXECUTION = "remote action execution";
   public static final String CAT_REMOTE_OUTPUT_DOWNLOAD = "remote output download";
@@ -82,6 +84,10 @@ public class BazelProfileConstants {
   // CompleteEvent names
   public static final String COMPLETE_MAJOR_GARBAGE_COLLECTION = "major GC";
   public static final String COMPLETE_MINOR_GARBAGE_COLLECTION = "minor GC";
+
+  // One of the events written when an action is executed locally, see
+  // https://github.com/bazelbuild/bazel/blob/36614cf29867c7ca86ae44b60ac2d92dcf03f204/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java#L147
+  public static final String COMPLETE_SUBPROCESS_RUN = "subprocess.run";
   public static final String COMPLETE_EXECUTE_REMOTELY = "execute remotely";
 
   // InstantEvent names

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
@@ -9,6 +9,7 @@ TYPES = [
     "EstimatedCoresUsed.java",
     "EstimatedJobsFlagValue.java",
     "GarbageCollectionStats.java",
+    "LocalActions.java",
     "MergedEventsPresent.java",
     "TotalDuration.java",
 ]

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProvider.java
@@ -43,7 +43,7 @@ public class RemoteCacheMetricsDataProvider extends DataProvider {
   }
 
   RemoteCacheData coalesce(LocalAction action) {
-    return action.relatedEvents.stream()
+    return action.getRelatedEvents().stream()
         .reduce(RemoteCacheData.EMPTY, RemoteCacheData::plus, RemoteCacheData::plus)
         .calculateCacheState();
   }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
@@ -17,6 +17,7 @@ java_library(
     deps = [
         ":types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile",
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile:types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/core",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/LocalActionsWithRemoteExecutionSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/LocalActionsWithRemoteExecutionSuggestionProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.suggestionproviders;
+
+import com.engflow.bazel.invocation.analyzer.Caveat;
+import com.engflow.bazel.invocation.analyzer.Suggestion;
+import com.engflow.bazel.invocation.analyzer.SuggestionCategory;
+import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.core.DataManager;
+import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
+import com.engflow.bazel.invocation.analyzer.core.SuggestionProvider;
+import com.engflow.bazel.invocation.analyzer.dataproviders.LocalActions;
+import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteExecutionUsed;
+import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link SuggestionProvider} that suggests migrating locally executed events to remote execution
+ * if remote execution is already being used.
+ */
+public class LocalActionsWithRemoteExecutionSuggestionProvider extends SuggestionProviderBase {
+  private static final String ANALYZER_CLASSNAME =
+      LocalActionsWithRemoteExecutionSuggestionProvider.class.getName();
+  private static final String SUGGESTION_ID_LOCAL_ACTIONS_WITH_REMOTE_EXECUTION =
+      "LocalActionsWithRemoteExecution";
+
+  public static LocalActionsWithRemoteExecutionSuggestionProvider createDefault() {
+    return new LocalActionsWithRemoteExecutionSuggestionProvider(5);
+  }
+
+  public static LocalActionsWithRemoteExecutionSuggestionProvider createVerbose() {
+    return new LocalActionsWithRemoteExecutionSuggestionProvider(Integer.MAX_VALUE);
+  }
+
+  private final int maxActions;
+
+  @VisibleForTesting
+  LocalActionsWithRemoteExecutionSuggestionProvider(int maxActions) {
+    this.maxActions = maxActions;
+  }
+
+  @Override
+  public SuggestionOutput getSuggestions(DataManager dataManager) {
+    try {
+      boolean remoteExecutionUsed =
+          dataManager.getDatum(RemoteExecutionUsed.class).isRemoteExecutionUsed();
+      List<Suggestion> suggestions = new ArrayList<>();
+      List<Caveat> caveats = new ArrayList<>();
+      if (remoteExecutionUsed) {
+        var localActions = dataManager.getDatum(LocalActions.class);
+        if (!localActions.isEmpty()) {
+          var locallyExecuted =
+              localActions.stream()
+                  .filter(action -> action.isExecutedLocally())
+                  .sorted((a, b) -> b.getAction().duration.compareTo(a.getAction().duration))
+                  .collect(Collectors.toList());
+          if (locallyExecuted.size() > maxActions) {
+            caveats.add(
+                SuggestionProviderUtil.createCaveat(
+                    String.format(
+                        "Only the %d longest, locally executed actions of the %d found were"
+                            + " listed.",
+                        maxActions, locallyExecuted.size()),
+                    true));
+          }
+          StringBuilder recommendation = new StringBuilder();
+          recommendation.append(
+              "Although remote execution was used for this invocation, some actions were still"
+                  + " executed locally. Investigate whether you can migrate these actions to remote"
+                  + " execution to speed up future builds and improve hermeticity:\n");
+          locallyExecuted.stream()
+              .limit(maxActions)
+              .forEachOrdered(
+                  action -> {
+                    recommendation.append("\t- ");
+                    recommendation.append(action.getAction().name);
+                    recommendation.append(" (");
+                    recommendation.append(DurationUtil.formatDuration(action.getAction().duration));
+                    recommendation.append(")\n");
+                  });
+          suggestions.add(
+              SuggestionProviderUtil.createSuggestion(
+                  SuggestionCategory.OTHER,
+                  createSuggestionId(SUGGESTION_ID_LOCAL_ACTIONS_WITH_REMOTE_EXECUTION),
+                  "Migrate locally executed actions to remote execution",
+                  recommendation.toString(),
+                  null,
+                  null,
+                  caveats));
+        }
+      }
+      return SuggestionProviderUtil.createSuggestionOutput(ANALYZER_CLASSNAME, suggestions, null);
+    } catch (MissingInputException e) {
+      return SuggestionProviderUtil.createSuggestionOutputForMissingInput(ANALYZER_CLASSNAME, e);
+    } catch (Throwable t) {
+      return SuggestionProviderUtil.createSuggestionOutputForFailure(ANALYZER_CLASSNAME, t);
+    }
+  }
+}

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
@@ -45,6 +45,9 @@ public class SuggestionProviderUtil {
         verbose
             ? BottleneckSuggestionProvider.createVerbose()
             : BottleneckSuggestionProvider.createDefault(),
+        verbose
+            ? LocalActionsWithRemoteExecutionSuggestionProvider.createVerbose()
+            : LocalActionsWithRemoteExecutionSuggestionProvider.createDefault(),
         new BuildWithoutTheBytesSuggestionProvider(),
         new CriticalPathNotDominantSuggestionProvider(),
         new GarbageCollectionSuggestionProvider(),

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/EventThreadBuilder.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/EventThreadBuilder.java
@@ -1,4 +1,4 @@
-package com.engflow.bazel.invocation.analyzer.dataproviders;
+package com.engflow.bazel.invocation.analyzer;
 
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.complete;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mnemonic;
@@ -15,7 +15,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
-class EventThreadBuilder {
+public class EventThreadBuilder {
 
   private final int id;
   private final int pid;
@@ -26,13 +26,14 @@ class EventThreadBuilder {
   private int nextActionStart = 0;
   private int nextRelatedStart = 0;
 
-  EventThreadBuilder(int id, int index) {
+  public EventThreadBuilder(int id, int index) {
     this.id = id;
     this.pid = 1; // hard coded by bazel
     this.index = index;
   }
 
-  public CompleteEvent action(String name, String mnemonic, int start, int duration) {
+  public CompleteEvent actionProcessingAction(
+      String name, String mnemonic, int start, int duration) {
     CompleteEvent event =
         new CompleteEvent(
             name,
@@ -48,14 +49,14 @@ class EventThreadBuilder {
     return event;
   }
 
-  public CompleteEvent action(String name, String mnemonic, int duration) {
-    return action(name, mnemonic, nextActionStart, duration);
+  public CompleteEvent actionProcessingAction(String name, String mnemonic, int duration) {
+    return actionProcessingAction(name, mnemonic, nextActionStart, duration);
   }
 
-  public CompleteEvent related(int start, int duration, String category) {
+  public CompleteEvent related(int start, int duration, String category, String name) {
     var event =
         new CompleteEvent(
-            category,
+            name,
             category,
             Timestamp.ofSeconds(start),
             Duration.ofSeconds(duration),
@@ -67,11 +68,15 @@ class EventThreadBuilder {
     return event;
   }
 
+  public CompleteEvent related(int start, int duration, String category) {
+    return related(start, duration, category, category);
+  }
+
   public CompleteEvent related(int duration, String category) {
     return related(nextRelatedStart, duration, category);
   }
 
-  TraceEvent asEvent() {
+  public TraceEvent asEvent() {
     return thread(
         id,
         index,

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProviderTest.java
@@ -9,6 +9,7 @@ import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileCon
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.engflow.bazel.invocation.analyzer.EventThreadBuilder;
 import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
 import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
 import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
@@ -56,22 +57,23 @@ public class RemoteCacheMetricsDataProviderTest extends DataProviderUnitTestBase
             LocalActions.create(
                 List.of(
                     new LocalActions.LocalAction(
-                        thread.action("Cached Work", "WorkC", 5),
+                        thread.actionProcessingAction("Cached Work", "WorkC", 5),
                         List.of(
                             thread.related(1, CAT_REMOTE_ACTION_CACHE_CHECK),
                             thread.related(2, CAT_REMOTE_OUTPUT_DOWNLOAD))),
                     new LocalActions.LocalAction(
-                        thread.action("More Cached Work", "WorkC", 5),
+                        thread.actionProcessingAction("More Cached Work", "WorkC", 5),
                         List.of(
                             thread.related(4, CAT_REMOTE_ACTION_CACHE_CHECK),
                             thread.related(8, CAT_REMOTE_OUTPUT_DOWNLOAD))),
                     new LocalActions.LocalAction(
-                        thread.action("Cache Miss Work", "WorkC", 5),
+                        thread.actionProcessingAction("Cache Miss Work", "WorkC", 5),
                         List.of(
                             thread.related(16, CAT_REMOTE_ACTION_CACHE_CHECK),
                             thread.related(32, CAT_REMOTE_EXECUTION_UPLOAD_TIME))),
                     new LocalActions.LocalAction(
-                        thread.action("UnCached Work", "LocalWorkC", 5), List.of()))));
+                        thread.actionProcessingAction("UnCached Work", "LocalWorkC", 5),
+                        List.of()))));
 
     Truth.assertThat(provider.derive())
         .isEqualTo(

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
@@ -5,6 +5,7 @@ java_test(
     test_class = "com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteExecutionDataProviderSuite",
     deps = [
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile",
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile:types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/core",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution:types",

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BUILD
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BUILD
@@ -10,6 +10,7 @@ java_test(
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution:types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
+        "//analyzer/javatests/com/engflow/bazel/invocation/analyzer:test_base",
         "//proto:bazel_invocation_analyzer_java_proto",
         "//third_party/junit",
         "//third_party/mockito",

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/LocalActionsWithRemoteExecutionSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/LocalActionsWithRemoteExecutionSuggestionProviderTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.suggestionproviders;
+
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_GENERAL_INFORMATION;
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_LOCAL_ACTION_EXECUTION;
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_ACTION_EXECUTION;
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.COMPLETE_SUBPROCESS_RUN;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.engflow.bazel.invocation.analyzer.EventThreadBuilder;
+import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.dataproviders.LocalActions;
+import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteExecutionUsed;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LocalActionsWithRemoteExecutionSuggestionProviderTest
+    extends SuggestionProviderUnitTestBase {
+  // These variables are returned from calls to DataManager.getDatum for the associated types. They
+  // are set up with reasonable defaults before each test is run, but can be overridden within the
+  // tests when custom values are desired for the testing being conducted (without the need to
+  // re-initialize the mocking).
+  private RemoteExecutionUsed remoteExecutionUsed;
+  private LocalActions localActions;
+
+  @Before
+  public void setup() throws Exception {
+    // Create reasonable defaults and set up to return the class-variables when the associated types
+    // are requested.
+    when(dataManager.getDatum(RemoteExecutionUsed.class)).thenAnswer(i -> remoteExecutionUsed);
+    when(dataManager.getDatum(LocalActions.class)).thenAnswer(i -> localActions);
+
+    suggestionProvider = LocalActionsWithRemoteExecutionSuggestionProvider.createDefault();
+  }
+
+  @Test
+  public void shouldNotReturnSuggestionForLocalInvocation() {
+    remoteExecutionUsed = new RemoteExecutionUsed(false);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+
+  @Test
+  public void shouldNotReturnSuggestionForRemoteExecutionInvocationWithoutLocalActions() {
+    remoteExecutionUsed = new RemoteExecutionUsed(false);
+    localActions = LocalActions.create(List.of());
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+
+  @Test
+  public void shouldReturnSuggestionForRemoteExecutionInvocationWithLocalActions() {
+    remoteExecutionUsed = new RemoteExecutionUsed(true);
+    var thread = new EventThreadBuilder(1, 1);
+    var localAction1 =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction("a local action", "a", 10, 10),
+            List.of(thread.related(10, 2, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN)));
+    var remoteAction1 =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction("some remote action", "b", 20, 10),
+            List.of(thread.related(20, 2, CAT_REMOTE_ACTION_EXECUTION, "bar")));
+    var localAction2 =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction("another local action", "c", 30, 10),
+            List.of(thread.related(30, 2, CAT_LOCAL_ACTION_EXECUTION, "baz")));
+
+    localActions = LocalActions.create(List.of(localAction1, remoteAction1, localAction2));
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(LocalActionsWithRemoteExecutionSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getSuggestionList().size()).isEqualTo(1);
+    var suggestion = suggestionOutput.getSuggestion(0);
+    assertThat(suggestion.getRecommendation()).contains(localAction1.getAction().name);
+    assertThat(suggestion.getRecommendation()).contains(localAction2.getAction().name);
+    assertThat(suggestion.getRecommendation()).doesNotContain(remoteAction1.getAction().name);
+    assertThat(suggestion.getCaveatList()).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnSuggestionForRemoteExecutionInvocationWithTooManyLocalActions() {
+    suggestionProvider = new LocalActionsWithRemoteExecutionSuggestionProvider(1);
+    remoteExecutionUsed = new RemoteExecutionUsed(true);
+    var thread = new EventThreadBuilder(1, 1);
+    var localAction1 =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction("a local action", "a", 10, 10),
+            List.of(thread.related(10, 2, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN)));
+    var remoteAction1 =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction("some remote action", "b", 20, 10),
+            List.of(thread.related(20, 2, CAT_REMOTE_ACTION_EXECUTION, "bar")));
+    var localAction2 =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction("another local action", "c", 30, 100),
+            List.of(thread.related(30, 2, CAT_LOCAL_ACTION_EXECUTION, "baz")));
+
+    localActions = LocalActions.create(List.of(localAction1, remoteAction1, localAction2));
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(LocalActionsWithRemoteExecutionSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+    assertThat(suggestionOutput.getSuggestionList().size()).isEqualTo(1);
+    var suggestion = suggestionOutput.getSuggestion(0);
+    // This is the longest local action. It is included.
+    assertThat(suggestion.getRecommendation()).contains(localAction2.getAction().name);
+    // This is another local action, but it exceeds the max count, so it's not included.
+    assertThat(suggestion.getRecommendation()).doesNotContain(localAction1.getAction().name);
+    assertThat(suggestion.getRecommendation()).doesNotContain(remoteAction1.getAction().name);
+    assertThat(suggestion.getCaveatCount()).isEqualTo(1);
+    assertThat(suggestion.getCaveat(0).getSuggestVerboseMode()).isTrue();
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
@@ -25,6 +25,7 @@ import org.junit.runners.Suite;
   GarbageCollectionSuggestionProviderTest.class,
   IncompleteProfileSuggestionProviderTest.class,
   JobsSuggestionProviderTest.class,
+  LocalActionsWithRemoteExecutionSuggestionProviderTest.class,
   MergedEventsSuggestionProviderTest.class,
   NegligiblePhaseSuggestionProviderTest.class,
   QueuingSuggestionProviderTest.class,


### PR DESCRIPTION
Add a `SuggestionProvider` which, if remote execution is used, highlights which actions were run locally and suggests migrating them to remote execution, too. In default mode, the four longest local actions are listed.

Fixes #95.