### PR TITLE
[SuggestionProvider] Suggest using Skymeld

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
@@ -49,6 +49,7 @@ public class SuggestionProviderUtil {
         new CriticalPathNotDominantSuggestionProvider(),
         new GarbageCollectionSuggestionProvider(),
         new JobsSuggestionProvider(),
+        new UseSkymeldSuggestionProvider(),
         new NegligiblePhaseSuggestionProvider(),
         new QueuingSuggestionProvider(),
         new IncompleteProfileSuggestionProvider(),

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/UseSkymeldSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/UseSkymeldSuggestionProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.suggestionproviders;
+
+import com.engflow.bazel.invocation.analyzer.Caveat;
+import com.engflow.bazel.invocation.analyzer.Suggestion;
+import com.engflow.bazel.invocation.analyzer.SuggestionCategory;
+import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.core.DataManager;
+import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
+import com.engflow.bazel.invocation.analyzer.core.SuggestionProvider;
+import com.engflow.bazel.invocation.analyzer.dataproviders.BazelVersion;
+import com.engflow.bazel.invocation.analyzer.dataproviders.SkymeldUsed;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A {@link SuggestionProvider} that suggests using Skymeld where applicable. */
+public class UseSkymeldSuggestionProvider extends SuggestionProviderBase {
+  private static final String ANALYZER_CLASSNAME = UseSkymeldSuggestionProvider.class.getName();
+
+  private static final int BAZEL_MAJOR_VERSION_WITH_SKYMELD_SUPPORT = 6;
+  private static final String SUGGESTION_ID_USE_SKYMELD = "UseSkymeld";
+
+  @Override
+  public SuggestionOutput getSuggestions(DataManager dataManager) {
+    try {
+      boolean isSkymeldUsed = dataManager.getDatum(SkymeldUsed.class).isSkymeldUsed();
+      List<Suggestion> suggestions = new ArrayList<>();
+      if (!isSkymeldUsed) {
+        var bazelVersion = dataManager.getDatum(BazelVersion.class);
+
+        String title = "Enable Skymeld";
+        String recommendation =
+            "Consider setting the Bazel flag"
+                + " `--experimental_merged_skyframe_analysis_execution=true`.";
+        String rationale =
+            "Enabling Skymeld lets Bazel merge the analysis and execution phases of Skyframe. This"
+                + " can improve the build performance especially for multi-target builds. Once the"
+                + " analysis of one target is completed, execution can start without having to wait"
+                + " for the analysis of the other targets to complete.\n"
+                + "Also see https://github.com/bazelbuild/bazel/issues/14057";
+        ArrayList<Caveat> caveats = new ArrayList<>();
+        // Only include the caveat if we don't know whether Bazel 6+ was used.
+        if (bazelVersion.isEmpty()
+            || bazelVersion.getMajor().isEmpty()
+            || bazelVersion.getMajor().get() < BAZEL_MAJOR_VERSION_WITH_SKYMELD_SUPPORT) {
+          caveats.add(
+              SuggestionProviderUtil.createCaveat(
+                  "Skymeld support was added with release 6.0.0 and enabled by default with 7.0.0."
+                      + " The version you are using may not support it.",
+                  false));
+        }
+        suggestions.add(
+            SuggestionProviderUtil.createSuggestion(
+                SuggestionCategory.BAZEL_FLAGS,
+                createSuggestionId(SUGGESTION_ID_USE_SKYMELD),
+                title,
+                recommendation,
+                null,
+                List.of(rationale),
+                caveats));
+      }
+      return SuggestionProviderUtil.createSuggestionOutput(ANALYZER_CLASSNAME, suggestions, null);
+    } catch (MissingInputException e) {
+      return SuggestionProviderUtil.createSuggestionOutputForMissingInput(ANALYZER_CLASSNAME, e);
+    } catch (Throwable t) {
+      return SuggestionProviderUtil.createSuggestionOutputForFailure(ANALYZER_CLASSNAME, t);
+    }
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
@@ -28,5 +28,6 @@ import org.junit.runners.Suite;
   MergedEventsSuggestionProviderTest.class,
   NegligiblePhaseSuggestionProviderTest.class,
   QueuingSuggestionProviderTest.class,
+  UseSkymeldSuggestionProviderTest.class,
 })
 public class SuggestionProvidersTestSuite {}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/UseSkymeldSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/UseSkymeldSuggestionProviderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.suggestionproviders;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.dataproviders.BazelVersion;
+import com.engflow.bazel.invocation.analyzer.dataproviders.SkymeldUsed;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UseSkymeldSuggestionProviderTest extends SuggestionProviderUnitTestBase {
+  // These variables are returned from calls to DataManager.getDatum for the associated types. They
+  // are set up with reasonable defaults before each test is run, but can be overridden within the
+  // tests when custom values are desired for the testing being conducted (without the need to
+  // re-initialize the mocking).
+  private BazelVersion bazelVersion;
+  private SkymeldUsed skymeldUsed;
+
+  @Before
+  public void setup() throws Exception {
+    // Create reasonable defaults and set up to return the class-variables when the associated types
+    // are requested.
+    when(dataManager.getDatum(BazelVersion.class)).thenAnswer(i -> bazelVersion);
+    when(dataManager.getDatum(SkymeldUsed.class)).thenAnswer(i -> skymeldUsed);
+
+    suggestionProvider = new UseSkymeldSuggestionProvider();
+  }
+
+  @Test
+  public void shouldReturnSuggestionForNoSkymeldUsedOnUnknownVersion() {
+    bazelVersion = BazelVersion.parse(null);
+    skymeldUsed = new SkymeldUsed(false);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(UseSkymeldSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).hasSize(1);
+    assertThat(suggestionOutput.getSuggestion(0).getCaveatCount()).isEqualTo(1);
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+
+  @Test
+  public void shouldReturnSuggestionForNoSkymeldUsedOnKnownOldVersion() {
+    bazelVersion = BazelVersion.parse("release 5.3.1");
+    skymeldUsed = new SkymeldUsed(false);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(UseSkymeldSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).hasSize(1);
+    assertThat(suggestionOutput.getSuggestion(0).getCaveatCount()).isEqualTo(1);
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+
+  @Test
+  public void shouldReturnSuggestionForNoSkymeldUsedOnKnownNewVersion() {
+    bazelVersion = BazelVersion.parse("release 7.0.0");
+    skymeldUsed = new SkymeldUsed(false);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(UseSkymeldSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).hasSize(1);
+    assertThat(suggestionOutput.getSuggestion(0).getCaveatList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+
+  @Test
+  public void shouldReturnNoSuggestionForSkymeldUsed() {
+    skymeldUsed = new SkymeldUsed(true);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(UseSkymeldSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+}


### PR DESCRIPTION
If the profile indicates Skymeld was not used, suggest enabling it. A caveat is included if the Bazel profile doesn't report a Bazel version that supports Skymeld

Fixes #91