### PR TITLE
[BottleneckSuggestionProvider] Add target for action, if available.

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
@@ -97,4 +97,14 @@ public class BazelProfileConstants {
   // See
   // https://github.com/bazelbuild/bazel/blob/aab19f75cd383c4b09a6ae720f9fa436bf89d271/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java#L179-L183
   public static final String OTHER_DATA_BAZEL_VERSION = "bazel_version";
+
+  // args names
+  // For "action processing" events, the target name is included in the args when setting the Bazel
+  // flag `--experimental_profile_include_target_label`
+  // See
+  // https://github.com/bazelbuild/bazel/blob/7d10999fc0357596824f2b6022bbbd895f245a3c/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java#L206-L208
+  public static final String ARGS_CAT_ACTION_PROCESSING_TARGET = "target";
+  // See
+  // https://github.com/bazelbuild/bazel/blob/7d10999fc0357596824f2b6022bbbd895f245a3c/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java#L209-L211
+  public static final String ARGS_CAT_ACTION_PROCESSING_MNEMONIC = "mnemonic";
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/BUILD
@@ -9,6 +9,7 @@ TYPES = [
     "EstimatedCoresAvailable.java",
     "EstimatedCoresUsed.java",
     "EstimatedJobsFlagValue.java",
+    "FlagValueExperimentalProfileIncludeTargetLabel.java",
     "GarbageCollectionStats.java",
     "LocalActions.java",
     "MergedEventsPresent.java",

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/DataProviderUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/DataProviderUtil.java
@@ -36,6 +36,7 @@ public class DataProviderUtil {
         new BazelVersionDataProvider(),
         new CriticalPathDurationDataProvider(),
         new EstimatedCoresDataProvider(),
+        new FlagValueDataProvider(),
         new GarbageCollectionStatsDataProvider(),
         new LocalActionsDataProvider(),
         new MergedEventsPresentDataProvider(),

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueDataProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.dataproviders;
+
+import static com.engflow.bazel.invocation.analyzer.core.DatumSupplier.memoized;
+
+import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfile;
+import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
+import com.engflow.bazel.invocation.analyzer.core.DataProvider;
+import com.engflow.bazel.invocation.analyzer.core.DatumSupplierSpecification;
+import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
+import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
+import com.engflow.bazel.invocation.analyzer.core.NullDatumException;
+import java.util.List;
+
+/**
+ * A {@link DataProvider} that supplies data on whether specific Bazel flags were used when the
+ * Bazel profile was generated.
+ */
+public class FlagValueDataProvider extends DataProvider {
+  @Override
+  public List<DatumSupplierSpecification<?>> getSuppliers() {
+    return List.of(
+        DatumSupplierSpecification.of(
+            FlagValueExperimentalProfileIncludeTargetLabel.class,
+            memoized(this::getExperimentalProfileIncludeTargetLabel)));
+  }
+
+  public FlagValueExperimentalProfileIncludeTargetLabel getExperimentalProfileIncludeTargetLabel()
+      throws InvalidProfileException, MissingInputException, NullDatumException {
+    BazelProfile bazelProfile = getDataManager().getDatum(BazelProfile.class);
+    // See
+    // https://github.com/bazelbuild/bazel/blob/7d10999fc0357596824f2b6022bbbd895f245a3c/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java#L395
+    // https://github.com/bazelbuild/bazel/blob/7d10999fc0357596824f2b6022bbbd895f245a3c/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java#L818
+    // https://github.com/bazelbuild/bazel/blob/7d10999fc0357596824f2b6022bbbd895f245a3c/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java#L206-L208
+    var hasTarget =
+        bazelProfile
+            .getThreads()
+            .flatMap(profileThread -> profileThread.getCompleteEvents().stream())
+            .anyMatch(
+                event ->
+                    BazelProfileConstants.CAT_ACTION_PROCESSING.equals(event.category)
+                        && event.args.containsKey(
+                            BazelProfileConstants.ARGS_CAT_ACTION_PROCESSING_TARGET));
+    return new FlagValueExperimentalProfileIncludeTargetLabel(hasTarget);
+  }
+}

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueDataProvider.java
@@ -23,6 +23,7 @@ import com.engflow.bazel.invocation.analyzer.core.DatumSupplierSpecification;
 import com.engflow.bazel.invocation.analyzer.core.InvalidProfileException;
 import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
 import com.engflow.bazel.invocation.analyzer.core.NullDatumException;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /**
@@ -32,7 +33,7 @@ import java.util.List;
 public class FlagValueDataProvider extends DataProvider {
   @Override
   public List<DatumSupplierSpecification<?>> getSuppliers() {
-    return List.of(
+    return ImmutableList.of(
         DatumSupplierSpecification.of(
             FlagValueExperimentalProfileIncludeTargetLabel.class,
             memoized(this::getExperimentalProfileIncludeTargetLabel)));

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueExperimentalProfileIncludeTargetLabel.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueExperimentalProfileIncludeTargetLabel.java
@@ -18,8 +18,8 @@ import com.engflow.bazel.invocation.analyzer.core.Datum;
 import java.util.Objects;
 
 /**
- * Whether the Bazel flag `--experimental_profile_include_target_label` was enabled when the Bazel
- * profile was generated.
+ * Whether the Bazel flag {@code --experimental_profile_include_target_label} was enabled when the
+ * Bazel profile was generated.
  *
  * @see <a
  *     href="https://bazel.build/reference/command-line-reference#flag--experimental_profile_include_target_label">Bazel
@@ -64,7 +64,7 @@ public class FlagValueExperimentalProfileIncludeTargetLabel implements Datum {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof FlagValueExperimentalProfileIncludeTargetLabel)) {
       return false;
     }
     FlagValueExperimentalProfileIncludeTargetLabel that =
@@ -79,6 +79,7 @@ public class FlagValueExperimentalProfileIncludeTargetLabel implements Datum {
 
   @Override
   public String toString() {
-    return String.valueOf(profileIncludeTargetLabelEnabled);
+    return String.format(
+        "FlagValueExperimentalProfileIncludeTargetLabel{%b}", profileIncludeTargetLabelEnabled);
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueExperimentalProfileIncludeTargetLabel.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueExperimentalProfileIncludeTargetLabel.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.dataproviders;
+
+import com.engflow.bazel.invocation.analyzer.core.Datum;
+import java.util.Objects;
+
+/**
+ * Whether the Bazel flag `--experimental_profile_include_target_label` was enabled when the Bazel
+ * profile was generated.
+ *
+ * @see <a
+ *     href="https://bazel.build/reference/command-line-reference#flag--experimental_profile_include_target_label">Bazel
+ *     Command-Line Reference</a>
+ */
+public class FlagValueExperimentalProfileIncludeTargetLabel implements Datum {
+  public static final String FLAG_NAME = "--experimental_profile_include_target_label";
+  public static final String COMMAND_LINE_REFERENCE_URL =
+      "https://bazel.build/reference/command-line-reference#flag--experimental_profile_include_target_label";
+  private final boolean profileIncludeTargetLabelEnabled;
+
+  public FlagValueExperimentalProfileIncludeTargetLabel(boolean profileIncludeTargetLabelEnabled) {
+    this.profileIncludeTargetLabelEnabled = profileIncludeTargetLabelEnabled;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public String getEmptyReason() {
+    return null;
+  }
+
+  public boolean isProfileIncludeTargetLabelEnabled() {
+    return profileIncludeTargetLabelEnabled;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Whether the Bazel flag `--experimental_profile_include_target_label` was enabled when"
+        + " the Bazel profile was generated.";
+  }
+
+  public String getSummary() {
+    return String.valueOf(profileIncludeTargetLabelEnabled);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FlagValueExperimentalProfileIncludeTargetLabel that =
+        (FlagValueExperimentalProfileIncludeTargetLabel) o;
+    return profileIncludeTargetLabelEnabled == that.profileIncludeTargetLabelEnabled;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(profileIncludeTargetLabelEnabled);
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(profileIncludeTargetLabelEnabled);
+  }
+}

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
@@ -134,7 +134,8 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
       final List<Caveat> caveats = new ArrayList<>();
       var flagForTargetInclusionEnabled =
           dataManager.getDatum(FlagValueExperimentalProfileIncludeTargetLabel.class);
-      if (!flagForTargetInclusionEnabled.isProfileIncludeTargetLabelEnabled()) {
+      if (suggestions.size() > 0
+          && !flagForTargetInclusionEnabled.isProfileIncludeTargetLabelEnabled()) {
         caveats.add(
             SuggestionProviderUtil.createCaveat(
                 String.format(
@@ -274,11 +275,9 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
               }
               sb.append("\t\tAction duration: ");
               sb.append(formatDuration(event.completeEvent.duration));
-              sb.append("\n");
               if (event.isCropped()) {
-                sb.append("\t\tDuration within bottleneck: ");
+                sb.append("\n\t\tDuration within bottleneck: ");
                 sb.append(formatDuration(event.croppedDuration));
-                sb.append("\n");
               }
               return sb.toString();
             })

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProvider.java
@@ -21,15 +21,18 @@ import com.engflow.bazel.invocation.analyzer.PotentialImprovement;
 import com.engflow.bazel.invocation.analyzer.Suggestion;
 import com.engflow.bazel.invocation.analyzer.SuggestionCategory;
 import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
 import com.engflow.bazel.invocation.analyzer.core.DataManager;
 import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
 import com.engflow.bazel.invocation.analyzer.dataproviders.ActionStats;
 import com.engflow.bazel.invocation.analyzer.dataproviders.Bottleneck;
 import com.engflow.bazel.invocation.analyzer.dataproviders.EstimatedCoresUsed;
+import com.engflow.bazel.invocation.analyzer.dataproviders.FlagValueExperimentalProfileIncludeTargetLabel;
 import com.engflow.bazel.invocation.analyzer.dataproviders.TotalDuration;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import com.engflow.bazel.invocation.analyzer.traceeventformat.PartialCompleteEvent;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -106,7 +109,6 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
       }
       final var totalDuration = totalDurationDatum.getTotalDuration().get();
 
-      final List<Caveat> caveats = new ArrayList<>();
       final var suggestions =
           bottlenecks.stream()
               // Only consider bottlenecks with sufficiently fewer actions than cores used.
@@ -129,6 +131,20 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
               .map(bottleneckStats -> generateSuggestion(bottleneckStats, totalDuration))
               .collect(Collectors.toList());
 
+      final List<Caveat> caveats = new ArrayList<>();
+      var flagForTargetInclusionEnabled =
+          dataManager.getDatum(FlagValueExperimentalProfileIncludeTargetLabel.class);
+      if (!flagForTargetInclusionEnabled.isProfileIncludeTargetLabelEnabled()) {
+        caveats.add(
+            SuggestionProviderUtil.createCaveat(
+                String.format(
+                    "The profile does not include which target each action was processed for,"
+                        + " although that data can help with breaking down bottlenecks. It is added"
+                        + " to the profile by using the Bazel flag `%s`. Also see %s",
+                    FlagValueExperimentalProfileIncludeTargetLabel.FLAG_NAME,
+                    FlagValueExperimentalProfileIncludeTargetLabel.COMMAND_LINE_REFERENCE_URL),
+                false));
+      }
       if (suggestions.size() < bottlenecks.size()) {
         String caveat;
         switch (suggestions.size()) {
@@ -244,17 +260,27 @@ public class BottleneckSuggestionProvider extends SuggestionProviderBase {
         .limit(maxActionsPerBottleneck)
         .map(
             event -> {
-              if (event.isCropped()) {
-                return String.format(
-                    "\t- %s (partially: %s of %s)",
-                    event.completeEvent.name,
-                    formatDuration(event.croppedDuration),
-                    formatDuration(event.completeEvent.duration));
-              } else {
-                return String.format(
-                    "\t- %s (%s)",
-                    event.completeEvent.name, formatDuration(event.completeEvent.duration));
+              StringBuilder sb = new StringBuilder();
+              sb.append("\t- Action: \"");
+              sb.append(event.completeEvent.name);
+              sb.append("\"\n");
+              var forTarget =
+                  event.completeEvent.args.get(
+                      BazelProfileConstants.ARGS_CAT_ACTION_PROCESSING_TARGET);
+              if (!Strings.isNullOrEmpty(forTarget)) {
+                sb.append("\t\tTarget: \"");
+                sb.append(forTarget);
+                sb.append("\"\n");
               }
+              sb.append("\t\tAction duration: ");
+              sb.append(formatDuration(event.completeEvent.duration));
+              sb.append("\n");
+              if (event.isCropped()) {
+                sb.append("\t\tDuration within bottleneck: ");
+                sb.append(formatDuration(event.croppedDuration));
+                sb.append("\n");
+              }
+              return sb.toString();
             })
         .collect(Collectors.joining("\n"));
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/WriteBazelProfile.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/WriteBazelProfile.java
@@ -257,14 +257,10 @@ public class WriteBazelProfile {
             put(TraceEventFormatConstants.EVENT_ARGUMENTS, properties));
   }
 
-  /**
-   * A mnemonic to add to the args.
-   *
-   * @param name for the event
-   */
+  /** A property, e.g. to add to the args. */
   @CheckReturnValue
-  public static Property mnemonic(String name) {
-    return writer -> writer.put("mnemonic", name);
+  public static Property property(String key, String value) {
+    return writer -> writer.put(key, value);
   }
 
   /**

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/DataProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/DataProvidersTestSuite.java
@@ -27,6 +27,7 @@ import org.junit.runners.Suite;
   BazelProfilePhaseTest.class,
   CriticalPathDurationDataProviderTest.class,
   EstimatedCoresDataProviderTest.class,
+  FlagValueDataProviderTest.class,
   GarbageCollectionStatsDataProviderTest.class,
   LocalActionsDataProviderTest.class,
   MergedEventsPresentDataProviderTest.class,

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueDataProviderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.dataproviders;
+
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.thread;
+import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.engflow.bazel.invocation.analyzer.EventThreadBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FlagValueDataProviderTest extends DataProviderUnitTestBase {
+  private FlagValueDataProvider provider;
+
+  @Before
+  public void setupTest() throws Exception {
+    provider = new FlagValueDataProvider();
+    provider.register(dataManager);
+    super.dataProvider = provider;
+  }
+
+  @Test
+  public void flagValueExperimentalProfileIncludeTargetLabelIsFalseWhenThereAreNoActions()
+      throws Exception {
+    useProfile(metaData(), trace(mainThread()));
+
+    assertThat(provider.getExperimentalProfileIncludeTargetLabel())
+        .isEqualTo(new FlagValueExperimentalProfileIncludeTargetLabel(false));
+  }
+
+  @Test
+  public void
+      flagValueExperimentalProfileIncludeTargetLabelIsFalseWhenActionProcessingDoesNotHaveALabel()
+          throws Exception {
+    var thread = new EventThreadBuilder(1, 1);
+    thread.actionProcessingAction("foo", null, null, 0, 1);
+
+    useProfile(metaData(), trace(mainThread(), thread.asEvent()));
+
+    assertThat(provider.getExperimentalProfileIncludeTargetLabel())
+        .isEqualTo(new FlagValueExperimentalProfileIncludeTargetLabel(false));
+  }
+
+  @Test
+  public void
+      flagValueExperimentalProfileIncludeTargetLabelIsTrueWhenActionProcessingHasAnEmptyLabel()
+          throws Exception {
+    var thread = new EventThreadBuilder(1, 1);
+    thread.actionProcessingAction("foo", "", null, 0, 1);
+
+    useProfile(metaData(), trace(mainThread(), thread.asEvent()));
+
+    assertThat(provider.getExperimentalProfileIncludeTargetLabel())
+        .isEqualTo(new FlagValueExperimentalProfileIncludeTargetLabel(true));
+  }
+
+  @Test
+  public void
+      flagValueExperimentalProfileIncludeTargetLabelIsTrueWhenActionProcessingHasANonemptyLabel()
+          throws Exception {
+    var thread = new EventThreadBuilder(1, 1);
+    thread.actionProcessingAction("foo", "my target", null, 0, 1);
+
+    useProfile(metaData(), trace(mainThread(), thread.asEvent()));
+
+    assertThat(provider.getExperimentalProfileIncludeTargetLabel())
+        .isEqualTo(new FlagValueExperimentalProfileIncludeTargetLabel(true));
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/BottleneckSuggestionProviderTest.java
@@ -53,7 +53,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
         .thenReturn(new TotalDuration(Duration.ofSeconds(100)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -73,7 +73,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
         .thenReturn(new TotalDuration(Duration.ofSeconds(100)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -91,7 +91,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(TotalDuration.class)).thenReturn(new TotalDuration("empty"));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -110,7 +110,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of()));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -133,7 +133,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, minDuration, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, minDuration, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -155,7 +155,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).hasSize(1);
     assertThat(suggestions.hasFailure()).isFalse();
@@ -178,7 +178,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).hasSize(1);
     assertThat(suggestions.getSuggestion(0).getId())
@@ -203,7 +203,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).hasSize(1);
     assertThat(suggestions.getSuggestion(0).getId())
@@ -227,7 +227,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 100, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 100, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.hasFailure()).isFalse();
@@ -280,7 +280,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
         .thenReturn(new ActionStats(List.of(minorBottleneck, majorBottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionCount()).isEqualTo(1);
     assertThat(suggestions.getSuggestion(0).getRationaleCount()).isEqualTo(1);
@@ -304,7 +304,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of()));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).isEmpty();
     assertThat(suggestions.getCaveatList()).isEmpty();
@@ -329,7 +329,7 @@ public class BottleneckSuggestionProviderTest extends SuggestionProviderUnitTest
     when(dataManager.getDatum(ActionStats.class)).thenReturn(new ActionStats(List.of(bottleneck)));
 
     final var bottleneckSuggestionProvider =
-        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1.);
+        new BottleneckSuggestionProvider(1, 1, Duration.ZERO, 0, 1);
     final var suggestions = bottleneckSuggestionProvider.getSuggestions(dataManager);
     assertThat(suggestions.getSuggestionList()).hasSize(1);
     assertThat(suggestions.getCaveatList()).hasSize(1);


### PR DESCRIPTION
When using the flag `--experimental_profile_include_target_label` when a Bazel profile is generated, action processing events include which target the action is being processed for.
If present, add this information to the "Break down bottlenecks" suggestions. If not present, add a caveat that highlights the flag could be set to improve the bottleneck suggestions.

Fixes #92.