### PR TITLE
[SuggestionProvider] Suggest using a remote cache, if not done yet

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteCachingUsedDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/RemoteCachingUsedDataProvider.java
@@ -41,6 +41,14 @@ public class RemoteCachingUsedDataProvider extends DataProvider {
   @VisibleForTesting
   RemoteCachingUsed getRemoteCachingUsed()
       throws InvalidProfileException, MissingInputException, NullDatumException {
+    RemoteExecutionUsed remoteExecutionUsed = getDataManager().getDatum(RemoteExecutionUsed.class);
+    if (remoteExecutionUsed.isRemoteExecutionUsed()) {
+      // While in principle it is possible to use remote execution without remote caching, this is
+      // a highly unusual setup. Return `true` here to avoid false negatives.
+      // For example, if RE is enabled and only targets with tag `no-remote-cache` or `no-cache`
+      // were built, the code farther down may not correctly detect that RC was used.
+      return new RemoteCachingUsed(true);
+    }
     BazelProfile profile = getDataManager().getDatum(BazelProfile.class);
     return new RemoteCachingUsed(
         profile

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProviderUtil.java
@@ -56,6 +56,7 @@ public class SuggestionProviderUtil {
         new UseSkymeldSuggestionProvider(),
         new NegligiblePhaseSuggestionProvider(),
         new QueuingSuggestionProvider(),
+        new UseRemoteCachingSuggestionProvider(),
         new IncompleteProfileSuggestionProvider(),
         // Consciously put this suggestion last, as it's not about the invocation itself,
         // but guidance on how to potentially get a better analysis using this tool.

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/UseRemoteCachingSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/UseRemoteCachingSuggestionProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.suggestionproviders;
+
+import com.engflow.bazel.invocation.analyzer.Suggestion;
+import com.engflow.bazel.invocation.analyzer.SuggestionCategory;
+import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.core.DataManager;
+import com.engflow.bazel.invocation.analyzer.core.MissingInputException;
+import com.engflow.bazel.invocation.analyzer.core.SuggestionProvider;
+import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteCachingUsed;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A {@link SuggestionProvider} that suggests using remote caching, if not already used. */
+public class UseRemoteCachingSuggestionProvider extends SuggestionProviderBase {
+  private static final String ANALYZER_CLASSNAME =
+      UseRemoteCachingSuggestionProvider.class.getName();
+  private static final String SUGGESTION_ID_USE_REMOTE_CACHING = "UseRemoteCaching";
+
+  @Override
+  public SuggestionOutput getSuggestions(DataManager dataManager) {
+    try {
+      boolean remoteCachingUsed =
+          dataManager.getDatum(RemoteCachingUsed.class).isRemoteCachingUsed();
+      List<Suggestion> suggestions = new ArrayList<>();
+      if (!remoteCachingUsed) {
+        String title = "Use remote caching";
+        String recommendation =
+            "Consider using remote caching to speed up builds: https://bazel.build/remote/caching\n"
+                + "There are two kinds of remote caches you can set up. The first is configured"
+                + " with the Bazel flag `--remote_cache` and leverages a separate service for"
+                + " caching, which usually runs on a different machine. The second cache is"
+                + " configured with the Bazel flag `--disk_cache` and uses your local disk. It is"
+                + " possible and in many cases recommended to use both `--disk_cache` and"
+                + " `--remote_cache` together.";
+        String rationale =
+            "A remote cache allows you to share build outputs between different Bazel clients. This"
+                + " can make builds significantly faster.";
+        suggestions.add(
+            SuggestionProviderUtil.createSuggestion(
+                SuggestionCategory.BAZEL_FLAGS,
+                createSuggestionId(SUGGESTION_ID_USE_REMOTE_CACHING),
+                title,
+                recommendation,
+                null,
+                List.of(rationale),
+                null));
+      }
+      return SuggestionProviderUtil.createSuggestionOutput(ANALYZER_CLASSNAME, suggestions, null);
+    } catch (MissingInputException e) {
+      return SuggestionProviderUtil.createSuggestionOutputForMissingInput(ANALYZER_CLASSNAME, e);
+    } catch (Throwable t) {
+      return SuggestionProviderUtil.createSuggestionOutputForFailure(ANALYZER_CLASSNAME, t);
+    }
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
@@ -29,6 +29,7 @@ import org.junit.runners.Suite;
   MergedEventsSuggestionProviderTest.class,
   NegligiblePhaseSuggestionProviderTest.class,
   QueuingSuggestionProviderTest.class,
+  UseRemoteCachingSuggestionProviderTest.class,
   UseSkymeldSuggestionProviderTest.class,
 })
 public class SuggestionProvidersTestSuite {}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/UseRemoteCachingSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/UseRemoteCachingSuggestionProviderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.suggestionproviders;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteCachingUsed;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UseRemoteCachingSuggestionProviderTest extends SuggestionProviderUnitTestBase {
+  // These variables are returned from calls to DataManager.getDatum for the associated types. They
+  // are set up with reasonable defaults before each test is run, but can be overridden within the
+  // tests when custom values are desired for the testing being conducted (without the need to
+  // re-initialize the mocking).
+  private RemoteCachingUsed remoteCachingUsed;
+
+  @Before
+  public void setup() throws Exception {
+    // Create reasonable defaults and set up to return the class-variables when the associated types
+    // are requested.
+    when(dataManager.getDatum(RemoteCachingUsed.class)).thenAnswer(i -> remoteCachingUsed);
+
+    suggestionProvider = new UseRemoteCachingSuggestionProvider();
+  }
+
+  @Test
+  public void shouldReturnSuggestionIfRemoteCachingIsNotUsed() {
+    remoteCachingUsed = new RemoteCachingUsed(false);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+    assertThat(suggestionOutput.getAnalyzerClassname())
+        .isEqualTo(UseRemoteCachingSuggestionProvider.class.getName());
+    assertThat(suggestionOutput.getSuggestionList().size()).isEqualTo(1);
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+
+  @Test
+  public void shouldNotReturnSuggestionIfRemoteCachingIsUsed() {
+    remoteCachingUsed = new RemoteCachingUsed(true);
+
+    SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
+    assertThat(suggestionOutput.getSuggestionList()).isEmpty();
+    assertThat(suggestionOutput.hasFailure()).isFalse();
+  }
+}


### PR DESCRIPTION
If the profile looks like remote caching was not used, suggest setting it up. The suggestion mentions both `--remote_cache` and `--disk_cache` as options that you can combine, and links to Bazel documentation.

Fixes #127