### PR TITLE
[CODEOWNERS] Update who is automatically added as a reviewer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @EngFlow/admin @lrgoldstein @restingbull @saraadams @TheGrizzlyDev @WillEngFlow
+* @laszlocsomor @lrgoldstein @saraadams @WillEngFlow


### PR DESCRIPTION
* Remove broken `@Engflow/admin` entry
* Remove Antonio and Corbin
* Add Laszlo