### PR TITLE
[Refactor] Extract common methods: summary for complete event, target name missing info

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
@@ -38,6 +38,8 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         ":types",
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",
+        "//third_party/guava",
     ],
 )

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelEventsUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelEventsUtil.java
@@ -23,8 +23,10 @@ import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileCon
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.COMPLETE_REMOTE_EXECUTION_UPLOAD_TIME_UPLOAD;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.COMPLETE_REMOTE_EXECUTION_UPLOAD_TIME_UPLOAD_OUTPUTS;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.COMPLETE_SUBPROCESS_RUN;
+import static com.engflow.bazel.invocation.analyzer.time.DurationUtil.formatDuration;
 
 import com.engflow.bazel.invocation.analyzer.traceeventformat.CompleteEvent;
+import com.google.common.base.Strings;
 
 public final class BazelEventsUtil {
   private BazelEventsUtil() {}
@@ -66,5 +68,21 @@ public final class BazelEventsUtil {
     return CAT_REMOTE_EXECUTION_UPLOAD_TIME.equals(event.category)
         && (COMPLETE_REMOTE_EXECUTION_UPLOAD_TIME_UPLOAD_OUTPUTS.equals(event.name)
             || COMPLETE_REMOTE_EXECUTION_UPLOAD_TIME_UPLOAD.equals(event.name));
+  }
+
+  public static String summarizeCompleteEvent(CompleteEvent event) {
+    var summary = new StringBuilder();
+    summary.append("\t- Action: \"");
+    summary.append(event.name);
+    summary.append("\"\n");
+    var forTarget = event.args.get(BazelProfileConstants.ARGS_CAT_ACTION_PROCESSING_TARGET);
+    if (!Strings.isNullOrEmpty(forTarget)) {
+      summary.append("\t\tTarget: \"");
+      summary.append(forTarget);
+      summary.append("\"\n");
+    }
+    summary.append("\t\tAction duration: ");
+    summary.append(formatDuration(event.duration));
+    return summary.toString();
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelEventsUtil.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelEventsUtil.java
@@ -81,6 +81,12 @@ public final class BazelEventsUtil {
       summary.append(forTarget);
       summary.append("\"\n");
     }
+    var mnemonic = event.args.get(BazelProfileConstants.ARGS_CAT_ACTION_PROCESSING_MNEMONIC);
+    if (!Strings.isNullOrEmpty(mnemonic)) {
+      summary.append("\t\tMnemonic: \"");
+      summary.append(mnemonic);
+      summary.append("\"\n");
+    }
     summary.append("\t\tAction duration: ");
     summary.append(formatDuration(event.duration));
     return summary.toString();

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueExperimentalProfileIncludeTargetLabel.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueExperimentalProfileIncludeTargetLabel.java
@@ -52,7 +52,7 @@ public class FlagValueExperimentalProfileIncludeTargetLabel implements Datum {
   }
 
   /**
-   * Returns a st to enable this flag, given the cause.
+   * Returns a statement to enable this flag, given the cause.
    *
    * <p>The {@param useCase} should be of the shape, so that it fits into: {@code String.format("It
    * can help with %s.", useCase)}

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueExperimentalProfileIncludeTargetLabel.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/FlagValueExperimentalProfileIncludeTargetLabel.java
@@ -15,6 +15,8 @@
 package com.engflow.bazel.invocation.analyzer.dataproviders;
 
 import com.engflow.bazel.invocation.analyzer.core.Datum;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.util.Objects;
 
 /**
@@ -47,6 +49,21 @@ public class FlagValueExperimentalProfileIncludeTargetLabel implements Datum {
 
   public boolean isProfileIncludeTargetLabelEnabled() {
     return profileIncludeTargetLabelEnabled;
+  }
+
+  /**
+   * Returns a st to enable this flag, given the cause.
+   *
+   * <p>The {@param useCase} should be of the shape, so that it fits into: {@code String.format("It
+   * can help with %s.", useCase)}
+   */
+  public static String getNotSetButUsefulForStatement(String useCase) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(useCase));
+    return String.format(
+        "The profile does not include which target each action was processed for,"
+            + " although that data can help with %s. It is added to the profile by using the"
+            + " Bazel flag `%s`. Also see %s",
+        useCase, FLAG_NAME, COMMAND_LINE_REFERENCE_URL);
   }
 
   @Override

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/BUILD
@@ -4,6 +4,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile:types",
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile:util",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/core",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders:types",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution:types",

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelEventsUtilTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelEventsUtilTest.java
@@ -113,7 +113,7 @@ public class BazelEventsUtilTest {
   }
 
   @Test
-  public void summarizeCompleteActionWithoutTargetName() {
+  public void summarizeCompleteActionWithoutArgs() {
     var eventName = "some random name";
     var eventCategory = "that specific category";
     var eventDuration = Duration.ofSeconds(1234);
@@ -133,10 +133,11 @@ public class BazelEventsUtilTest {
   }
 
   @Test
-  public void summarizeCompleteActionWithTargetName() {
+  public void summarizeCompleteActionWithArgs() {
     var eventName = "some random name";
     var eventCategory = "that specific category";
     var eventDuration = Duration.ofSeconds(1234);
+    var mnemonic = "indicative stuff";
     var targetName = "for //target:foo";
     var event =
         new CompleteEvent(
@@ -146,10 +147,15 @@ public class BazelEventsUtilTest {
             eventDuration,
             1,
             1,
-            ImmutableMap.of(BazelProfileConstants.ARGS_CAT_ACTION_PROCESSING_TARGET, targetName));
+            ImmutableMap.of(
+                BazelProfileConstants.ARGS_CAT_ACTION_PROCESSING_MNEMONIC,
+                mnemonic,
+                BazelProfileConstants.ARGS_CAT_ACTION_PROCESSING_TARGET,
+                targetName));
     var summary = BazelEventsUtil.summarizeCompleteEvent(event);
     assertThat(summary).contains(eventName);
     assertThat(summary).contains(DurationUtil.formatDuration(eventDuration));
+    assertThat(summary).contains(mnemonic);
     assertThat(summary).contains(targetName);
     assertThat(summary).doesNotContain(eventCategory);
   }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelEventsUtilTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelEventsUtilTest.java
@@ -8,6 +8,7 @@ import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileCon
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_OUTPUT_DOWNLOAD;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import com.engflow.bazel.invocation.analyzer.traceeventformat.CompleteEvent;
 import com.google.common.collect.ImmutableMap;
@@ -109,6 +110,48 @@ public class BazelEventsUtilTest {
             BazelEventsUtil.indicatesRemoteUploadOutputs(
                 completeEvent("random name", CAT_REMOTE_EXECUTION_UPLOAD_TIME)))
         .isFalse();
+  }
+
+  @Test
+  public void summarizeCompleteActionWithoutTargetName() {
+    var eventName = "some random name";
+    var eventCategory = "that specific category";
+    var eventDuration = Duration.ofSeconds(1234);
+    var event =
+        new CompleteEvent(
+            eventName,
+            eventCategory,
+            Timestamp.ofSeconds(0),
+            eventDuration,
+            1,
+            1,
+            ImmutableMap.of());
+    var summary = BazelEventsUtil.summarizeCompleteEvent(event);
+    assertThat(summary).contains(eventName);
+    assertThat(summary).contains(DurationUtil.formatDuration(eventDuration));
+    assertThat(summary).doesNotContain(eventCategory);
+  }
+
+  @Test
+  public void summarizeCompleteActionWithTargetName() {
+    var eventName = "some random name";
+    var eventCategory = "that specific category";
+    var eventDuration = Duration.ofSeconds(1234);
+    var targetName = "for //target:foo";
+    var event =
+        new CompleteEvent(
+            eventName,
+            eventCategory,
+            Timestamp.ofSeconds(0),
+            eventDuration,
+            1,
+            1,
+            ImmutableMap.of(BazelProfileConstants.ARGS_CAT_ACTION_PROCESSING_TARGET, targetName));
+    var summary = BazelEventsUtil.summarizeCompleteEvent(event);
+    assertThat(summary).contains(eventName);
+    assertThat(summary).contains(DurationUtil.formatDuration(eventDuration));
+    assertThat(summary).contains(targetName);
+    assertThat(summary).doesNotContain(eventCategory);
   }
 
   private static CompleteEvent completeEvent(String name, String category) {

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
@@ -29,6 +29,7 @@ import org.junit.runners.Suite;
   LocalActionsWithRemoteExecutionSuggestionProviderTest.class,
   MergedEventsSuggestionProviderTest.class,
   NegligiblePhaseSuggestionProviderTest.class,
+  NoCacheActionsSuggestionProviderTest.class,
   QueuingSuggestionProviderTest.class,
   UseSkymeldSuggestionProviderTest.class,
 })

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/SuggestionProvidersTestSuite.java
@@ -29,7 +29,6 @@ import org.junit.runners.Suite;
   LocalActionsWithRemoteExecutionSuggestionProviderTest.class,
   MergedEventsSuggestionProviderTest.class,
   NegligiblePhaseSuggestionProviderTest.class,
-  NoCacheActionsSuggestionProviderTest.class,
   QueuingSuggestionProviderTest.class,
   UseSkymeldSuggestionProviderTest.class,
 })


### PR DESCRIPTION
This refactors some code, so that the way action processing events are printed out consistently, rather than having duplicate code.
It also refactors the code, so it's easy to add caveats relating to a profile not having the target names attached to actions.

Contributes to #133 