### PR TITLE
[SuggestionProvider] Fix bug in `InvestigateRemoteCacheMissesSuggestionProvider`

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/InvestigateRemoteCacheMissesSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/InvestigateRemoteCacheMissesSuggestionProvider.java
@@ -67,7 +67,7 @@ public class InvestigateRemoteCacheMissesSuggestionProvider extends SuggestionPr
       LocalActions localActions = dataManager.getDatum(LocalActions.class);
       var cacheMisses =
           localActions.stream()
-              .filter(action -> !action.isRemoteCacheHit())
+              .filter(action -> action.hasRemoteCacheCheck() && !action.isRemoteCacheHit())
               .sorted((a, b) -> b.getAction().duration.compareTo(a.getAction().duration))
               .collect(Collectors.toList());
       if (cacheMisses.isEmpty()) {

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/InvestigateRemoteCacheMissesSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/InvestigateRemoteCacheMissesSuggestionProviderTest.java
@@ -15,6 +15,7 @@
 package com.engflow.bazel.invocation.analyzer.suggestionproviders;
 
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_GENERAL_INFORMATION;
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_LOCAL_ACTION_EXECUTION;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_ACTION_CACHE_CHECK;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_ACTION_EXECUTION;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_OUTPUT_DOWNLOAD;
@@ -68,7 +69,19 @@ public class InvestigateRemoteCacheMissesSuggestionProviderTest
   @Test
   public void shouldNotReturnSuggestionWithoutCacheMisses() {
     remoteCachingUsed = new RemoteCachingUsed(true);
-    localActions = LocalActions.create(List.of());
+    var thread = new EventThreadBuilder(1, 1);
+    var actionWitRemoteCacheHit =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction("action with cache hit", "a", 10, 10),
+            List.of(
+                thread.related(10, 1, CAT_REMOTE_ACTION_CACHE_CHECK),
+                thread.related(12, 2, CAT_REMOTE_OUTPUT_DOWNLOAD)));
+    var actionWithoutRemoteCaching =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction("action without a cache check", "a", 10, 10),
+            List.of(thread.related(12, 2, CAT_LOCAL_ACTION_EXECUTION)));
+    localActions =
+        LocalActions.create(List.of(actionWitRemoteCacheHit, actionWithoutRemoteCaching));
 
     SuggestionOutput suggestionOutput = suggestionProvider.getSuggestions(dataManager);
 


### PR DESCRIPTION
Before, actions that did not check the remote cache were potentially included in the action misses suggestion.