### PR TITLE
[SuggestionProvider] Sort highlighted cache misses by execution time

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActions.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActions.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
@@ -143,6 +144,15 @@ public class LocalActions implements Datum, Iterable<LocalAction> {
 
     public CompleteEvent getAction() {
       return action;
+    }
+
+    public Duration getDurationWithoutCacheCheck() {
+      var cacheCheckDuration =
+          relatedEvents.stream()
+              .filter(BazelEventsUtil::indicatesRemoteCacheCheck)
+              .map(e -> e.duration)
+              .reduce(Duration.ZERO, Duration::plus);
+      return action.duration.minus(cacheCheckDuration);
     }
 
     public List<CompleteEvent> getRelatedEvents() {

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/InvestigateRemoteCacheMissesSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/InvestigateRemoteCacheMissesSuggestionProvider.java
@@ -65,7 +65,9 @@ public class InvestigateRemoteCacheMissesSuggestionProvider extends SuggestionPr
       var cacheMisses =
           localActions.stream()
               .filter(action -> action.hasRemoteCacheCheck() && !action.isRemoteCacheHit())
-              .sorted((a, b) -> b.getAction().duration.compareTo(a.getAction().duration))
+              .sorted(
+                  (a, b) ->
+                      b.getDurationWithoutCacheCheck().compareTo(a.getDurationWithoutCacheCheck()))
               .collect(Collectors.toList());
       if (cacheMisses.isEmpty()) {
         return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/DataProvidersTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/DataProvidersTestSuite.java
@@ -31,6 +31,7 @@ import org.junit.runners.Suite;
   FlagValueDataProviderTest.class,
   GarbageCollectionStatsDataProviderTest.class,
   LocalActionsDataProviderTest.class,
+  LocalActionsTest.class,
   MergedEventsPresentDataProviderTest.class,
   RemoteCacheMetricsDataProviderTest.class,
   SkymeldUsedDataProviderTest.class

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsDataProviderTest.java
@@ -17,11 +17,8 @@ package com.engflow.bazel.invocation.analyzer.dataproviders;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.mainThread;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.metaData;
 import static com.engflow.bazel.invocation.analyzer.WriteBazelProfile.trace;
-import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_GENERAL_INFORMATION;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_ACTION_CACHE_CHECK;
 import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_OUTPUT_DOWNLOAD;
-import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.COMPLETE_SUBPROCESS_RUN;
-import static com.google.common.truth.Truth.assertThat;
 
 import com.engflow.bazel.invocation.analyzer.EventThreadBuilder;
 import com.engflow.bazel.invocation.analyzer.core.DuplicateProviderException;
@@ -139,53 +136,5 @@ public class LocalActionsDataProviderTest extends DataProviderUnitTestBase {
 
     useProfile(metaData(), trace(mainThread(), one.asEvent(), two.asEvent()));
     expect.about(localActions).that(provider.derive()).isEqualTo(want);
-  }
-
-  @Test
-  public void isExecutedLocallyIsTrue() {
-    var thread = new EventThreadBuilder(1, 1);
-    var action =
-        new LocalAction(
-            thread.actionProcessingAction("my action", "foo", 10, 20),
-            List.of(thread.related(12, 2, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN)));
-    assertThat(action.isExecutedLocally()).isTrue();
-  }
-
-  @Test
-  public void isExecutedLocallyIsFalseNoEvent() {
-    var thread = new EventThreadBuilder(1, 1);
-    var action =
-        new LocalAction(thread.actionProcessingAction("my action", "foo", 10, 20), List.of());
-    assertThat(action.isExecutedLocally()).isFalse();
-  }
-
-  @Test
-  public void isExecutedLocallyIsFalseWrongCategory() {
-    var thread = new EventThreadBuilder(1, 1);
-    var action =
-        new LocalAction(
-            thread.actionProcessingAction("my action", "foo", 10, 20),
-            List.of(thread.related(12, 2, CAT_REMOTE_ACTION_CACHE_CHECK, COMPLETE_SUBPROCESS_RUN)));
-    assertThat(action.isExecutedLocally()).isFalse();
-  }
-
-  @Test
-  public void isExecutedLocallyIsFalseWrongName() {
-    var thread = new EventThreadBuilder(1, 1);
-    var action =
-        new LocalAction(
-            thread.actionProcessingAction("my action", "foo", 10, 20),
-            List.of(thread.related(12, 2, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN + "x")));
-    assertThat(action.isExecutedLocally()).isFalse();
-  }
-
-  @Test
-  public void isExecutedLocallyIsFalseEventOutOfRange() {
-    var thread = new EventThreadBuilder(1, 1);
-    var action =
-        new LocalAction(
-            thread.actionProcessingAction("my action", "foo", 10, 20),
-            List.of(thread.related(22, 1, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN)));
-    assertThat(action.isExecutedLocally()).isTrue();
   }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.dataproviders;
+
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_GENERAL_INFORMATION;
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_ACTION_CACHE_CHECK;
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.CAT_REMOTE_ACTION_EXECUTION;
+import static com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants.COMPLETE_SUBPROCESS_RUN;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.engflow.bazel.invocation.analyzer.EventThreadBuilder;
+import com.engflow.bazel.invocation.analyzer.dataproviders.LocalActions.LocalAction;
+import java.time.Duration;
+import java.util.List;
+import org.junit.Test;
+
+public class LocalActionsTest {
+  @Test
+  public void getDurationWithoutCacheCheck() {
+    int otherEvent1 = 1;
+    int cacheCheck1 = 2;
+    int cacheCheck2 = 4;
+    int otherEvent2 = 8;
+    int totalInSeconds = otherEvent1 + cacheCheck1 + cacheCheck2 + otherEvent2;
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("my action", "foo", 10, totalInSeconds),
+            List.of(
+                thread.related(otherEvent1, CAT_GENERAL_INFORMATION),
+                thread.related(cacheCheck1, CAT_REMOTE_ACTION_CACHE_CHECK),
+                thread.related(cacheCheck2, CAT_REMOTE_ACTION_CACHE_CHECK),
+                thread.related(otherEvent2, CAT_REMOTE_ACTION_EXECUTION)));
+    assertThat(action.getDurationWithoutCacheCheck())
+        .isEqualTo(
+            Duration.ofSeconds(totalInSeconds).minusSeconds(cacheCheck1).minusSeconds(cacheCheck2));
+  }
+
+  @Test
+  public void getDurationWithoutCacheCheckNoEvent() {
+    int durationInSeconds = 1234;
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("my action", "foo", 10, durationInSeconds),
+            List.of(
+                thread.related(2, CAT_GENERAL_INFORMATION),
+                thread.related(4, CAT_REMOTE_ACTION_EXECUTION)));
+    assertThat(action.getDurationWithoutCacheCheck())
+        .isEqualTo(Duration.ofSeconds(durationInSeconds));
+  }
+
+  @Test
+  public void isExecutedLocallyIsTrue() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("my action", "foo", 10, 20),
+            List.of(thread.related(12, 2, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN)));
+    assertThat(action.isExecutedLocally()).isTrue();
+  }
+
+  @Test
+  public void isExecutedLocallyIsFalseNoEvent() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(thread.actionProcessingAction("my action", "foo", 10, 20), List.of());
+    assertThat(action.isExecutedLocally()).isFalse();
+  }
+
+  @Test
+  public void isExecutedLocallyIsFalseWrongCategory() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("my action", "foo", 10, 20),
+            List.of(thread.related(12, 2, CAT_REMOTE_ACTION_CACHE_CHECK, COMPLETE_SUBPROCESS_RUN)));
+    assertThat(action.isExecutedLocally()).isFalse();
+  }
+
+  @Test
+  public void isExecutedLocallyIsFalseWrongName() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("my action", "foo", 10, 20),
+            List.of(thread.related(12, 2, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN + "x")));
+    assertThat(action.isExecutedLocally()).isFalse();
+  }
+
+  @Test
+  public void isExecutedLocallyIsFalseEventOutOfRange() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("my action", "foo", 10, 20),
+            List.of(thread.related(22, 1, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN)));
+    assertThat(action.isExecutedLocally()).isTrue();
+  }
+}


### PR DESCRIPTION
When highlighting cache misses sorted by their duration, exclude the time spent for checking the remote cache. This is more reflective of which cache misses you want to fix.

Contributes to #90