### PR TITLE
[DataProvider] Attempt to identify internal actions

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileConstants.java
@@ -138,4 +138,43 @@ public class BazelProfileConstants {
   // See
   // https://github.com/bazelbuild/bazel/blob/7d10999fc0357596824f2b6022bbbd895f245a3c/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java#L209-L211
   public static final String ARGS_CAT_ACTION_PROCESSING_MNEMONIC = "mnemonic";
+
+  // mnemonic names
+  // Some well-known mnemonic names that are included in the Bazel codebase itself.
+
+  // See
+  // https://github.com/bazelbuild/bazel/blob/c3ed4b5ab526405df336af94cf91145b682d1d04/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java#L253
+  /** For an action that creates a manifest file describing a symlink tree. */
+  public static final String MNEMONIC_BAZEL_WORKSPACE_STATUS_ACTION = "BazelWorkspaceStatusAction";
+
+  // See
+  // https://github.com/bazelbuild/bazel/blob/c3ed4b5ab526405df336af94cf91145b682d1d04/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java#L318
+  /** For an action that created an executable symlink. */
+  public static final String MNEMONIC_EXECUTABLE_SYMLINK = "ExecutableSymlink";
+  /** For an action that created a non-executable symlink. */
+  public static final String MNEMONIC_SYMLINK = "Symlink";
+
+  // See
+  // https://github.com/bazelbuild/bazel/blob/c3ed4b5ab526405df336af94cf91145b682d1d04/src/main/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteAction.java#L94
+
+  /** For an action that successfully wrote a file to disk. */
+  public static final String MNEMONIC_FILE_WRITE = "FileWrite";
+
+  // See
+  // https://github.com/bazelbuild/bazel/blob/c3ed4b5ab526405df336af94cf91145b682d1d04/src/main/java/com/google/devtools/build/lib/analysis/RepoMappingManifestAction.java#L119
+  /**
+   * For an action that creates a manifest file describing the repos and mappings relevant for a
+   * runfile tree.
+   */
+  public static final String MNEMONIC_REPO_MAPPING_MANIFEST = "RepoMappingManifest";
+
+  // See
+  // https://github.com/bazelbuild/bazel/blob/c3ed4b5ab526405df336af94cf91145b682d1d04/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java#L306
+  /** For an action that creates a manifest file describing a symlink tree. */
+  public static final String MNEMONIC_SOURCE_SYMLINK_MANIFEST = "SourceSymlinkManifest";
+
+  // See
+  // https://github.com/bazelbuild/bazel/blob/c3ed4b5ab526405df336af94cf91145b682d1d04/src/main/java/com/google/devtools/build/lib/analysis/actions/TemplateExpansionAction.java#L200
+  /** For an action that expands a template and writes the expanded content to a file. */
+  public static final String MNEMONIC_TEMPLATE_EXPAND = "TemplateExpand";
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CachingAndExecutionMetrics.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CachingAndExecutionMetrics.java
@@ -36,6 +36,7 @@ public class CachingAndExecutionMetrics implements Datum {
   private final long actionsWithRcMissExecNotReported;
   private final long actionsWithoutRcLocallyExecuted;
   private final long actionsWithoutRcRemotelyExecuted;
+  private final long actionsWithoutRcInternal;
   private final long actionsWithoutRcExecNotReported;
 
   public CachingAndExecutionMetrics(
@@ -46,6 +47,7 @@ public class CachingAndExecutionMetrics implements Datum {
       long actionsWithRcMissExecNotReported,
       long actionsWithoutRcLocallyExecuted,
       long actionsWithoutRcRemotelyExecuted,
+      long actionsWithoutRcInternal,
       long actionsWithoutRcExecNotReported) {
     this.actions = actions;
     this.actionsWithRcHit = actionsWithRcHit;
@@ -54,6 +56,7 @@ public class CachingAndExecutionMetrics implements Datum {
     this.actionsWithRcMissExecNotReported = actionsWithRcMissExecNotReported;
     this.actionsWithoutRcLocallyExecuted = actionsWithoutRcLocallyExecuted;
     this.actionsWithoutRcRemotelyExecuted = actionsWithoutRcRemotelyExecuted;
+    this.actionsWithoutRcInternal = actionsWithoutRcInternal;
     this.actionsWithoutRcExecNotReported = actionsWithoutRcExecNotReported;
   }
 
@@ -117,6 +120,16 @@ public class CachingAndExecutionMetrics implements Datum {
    */
   public long getActionsWithoutRcRemotelyExecuted() {
     return actionsWithoutRcRemotelyExecuted;
+  }
+
+  /**
+   * The number of actions processed that are likely internal actions.
+   *
+   * <p>{@link #getActionsWithoutRcExecNotReported()} equals out errors in the classification: False
+   * negatives are included there, and false positives should have been included there.
+   */
+  public long getActionsWithoutRcInternal() {
+    return actionsWithoutRcInternal;
   }
 
   /**
@@ -201,7 +214,10 @@ public class CachingAndExecutionMetrics implements Datum {
     sb.append(
         summarize(
             width, actionsWithoutRcRemotelyExecuted, getActionsWithoutRc(), "of all cache skips"));
-    sb.append("\n        Not reported (e.g. internal): ");
+    sb.append("\n        Internal (not exhaustive):    ");
+    sb.append(
+        summarize(width, actionsWithoutRcInternal, getActionsWithoutRc(), "of all cache skips"));
+    sb.append("\n        Not reported                  ");
     sb.append(
         summarize(
             width, actionsWithoutRcExecNotReported, getActionsWithoutRc(), "of all cache skips"));

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CachingAndExecutionMetricsDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/CachingAndExecutionMetricsDataProvider.java
@@ -50,6 +50,7 @@ public class CachingAndExecutionMetricsDataProvider extends DataProvider {
     AtomicLong cacheMissExecNotReported = new AtomicLong();
     AtomicLong nocacheLocalExec = new AtomicLong();
     AtomicLong nocacheRemoteExec = new AtomicLong();
+    AtomicLong nocacheInternal = new AtomicLong();
     AtomicLong nocacheExecNotReported = new AtomicLong();
     localActions.parallelStream()
         .forEach(
@@ -73,9 +74,13 @@ public class CachingAndExecutionMetricsDataProvider extends DataProvider {
                   nocacheLocalExec.getAndIncrement();
                 } else if (remoteExec) {
                   nocacheRemoteExec.getAndIncrement();
+
                 } else {
-                  // TODO: Can we separate out Bazel "internal" actions?
-                  nocacheExecNotReported.getAndIncrement();
+                  if (action.isInternal().orElse(false)) {
+                    nocacheInternal.getAndIncrement();
+                  } else {
+                    nocacheExecNotReported.getAndIncrement();
+                  }
                 }
               }
             });
@@ -87,6 +92,7 @@ public class CachingAndExecutionMetricsDataProvider extends DataProvider {
         cacheMissExecNotReported.get(),
         nocacheLocalExec.get(),
         nocacheRemoteExec.get(),
+        nocacheInternal.get(),
         nocacheExecNotReported.get());
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NoCacheActionsSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/NoCacheActionsSuggestionProvider.java
@@ -73,16 +73,16 @@ public class NoCacheActionsSuggestionProvider extends SuggestionProviderBase {
       if (localActions.isEmpty()) {
         return noSuggestions();
       }
-      var actionsWithoutRemoteCacheCheck =
+      var nonInternalActionsWithoutRemoteCacheCheck =
           localActions.stream()
-              .filter(action -> !action.hasRemoteCacheCheck())
+              .filter(action -> !action.hasRemoteCacheCheck() && !action.isInternal().orElse(false))
               .sorted((a, b) -> b.getAction().duration.compareTo(a.getAction().duration))
               .collect(Collectors.toList());
-      if (actionsWithoutRemoteCacheCheck.isEmpty()) {
+      if (nonInternalActionsWithoutRemoteCacheCheck.isEmpty()) {
         return noSuggestions();
       }
       var longEnoughActions =
-          actionsWithoutRemoteCacheCheck.stream()
+          nonInternalActionsWithoutRemoteCacheCheck.stream()
               .filter(action -> minDuration.compareTo(action.getAction().duration) <= 0)
               .collect(Collectors.toList());
       if (longEnoughActions.isEmpty()) {
@@ -94,7 +94,7 @@ public class NoCacheActionsSuggestionProvider extends SuggestionProviderBase {
                     String.format(
                         "%d actions do not check the remote cache, but none of them took longer"
                             + " than %s.",
-                        actionsWithoutRemoteCacheCheck.size(),
+                        nonInternalActionsWithoutRemoteCacheCheck.size(),
                         DurationUtil.formatDuration(minDuration)),
                     true)));
       }
@@ -114,14 +114,14 @@ public class NoCacheActionsSuggestionProvider extends SuggestionProviderBase {
                 String.format(
                     "Only the %d longest actions that did not check the remote cache of the"
                         + " %d found were listed.",
-                    maxActions, actionsWithoutRemoteCacheCheck.size()),
+                    maxActions, nonInternalActionsWithoutRemoteCacheCheck.size()),
                 true));
-      } else if (longEnoughActions.size() < actionsWithoutRemoteCacheCheck.size()) {
+      } else if (longEnoughActions.size() < nonInternalActionsWithoutRemoteCacheCheck.size()) {
         caveats.add(
             SuggestionProviderUtil.createCaveat(
                 String.format(
                     "%d actions did not take long enough to be listed.",
-                    actionsWithoutRemoteCacheCheck.size() - longEnoughActions.size()),
+                    nonInternalActionsWithoutRemoteCacheCheck.size() - longEnoughActions.size()),
                 true));
       }
       StringBuilder recommendation = new StringBuilder();

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/LocalActionsTest.java
@@ -109,4 +109,89 @@ public class LocalActionsTest {
             List.of(thread.related(22, 1, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN)));
     assertThat(action.isExecutedLocally()).isTrue();
   }
+
+  @Test
+  public void isInternalBazelWorkspaceStatusAction() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction(
+                "BazelWorkspaceStatusAction stable-status.txt",
+                "BazelWorkspaceStatusAction",
+                10,
+                20),
+            List.of());
+    assertThat(action.isInternal().isPresent()).isTrue();
+    assertThat(action.isInternal().get()).isTrue();
+  }
+
+  @Test
+  public void isInternalSymlink() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("Symlinking [...]", "Symlink", 10, 20), List.of());
+    assertThat(action.isInternal().isPresent()).isTrue();
+    assertThat(action.isInternal().get()).isTrue();
+  }
+
+  @Test
+  public void isInternalExecutableSymlink() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("Creating symlink [...]", "ExecutableSymlink", 10, 20),
+            List.of());
+    assertThat(action.isInternal().isPresent()).isTrue();
+    assertThat(action.isInternal().get()).isTrue();
+  }
+
+  @Test
+  public void isUnknownInternalNoMnemonic() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(thread.actionProcessingAction("action name", null, 10, 20), List.of());
+    assertThat(action.isInternal().isEmpty()).isTrue();
+  }
+
+  @Test
+  public void isUnknownInternalNoRecognizedMnemonic() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(thread.actionProcessingAction("action name", "foo", 10, 20), List.of());
+    assertThat(action.isInternal().isEmpty()).isTrue();
+  }
+
+  @Test
+  public void isNotInternalChecksRemoteCache() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("Creating symlink [...]", "ExecutableSymlink", 10, 20),
+            List.of(thread.related(1, CAT_REMOTE_ACTION_CACHE_CHECK)));
+    assertThat(action.isInternal().isPresent()).isTrue();
+    assertThat(action.isInternal().get()).isFalse();
+  }
+
+  @Test
+  public void isNotInternalLocallyExecuted() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("Creating symlink [...]", "ExecutableSymlink", 10, 20),
+            List.of(thread.related(1, CAT_GENERAL_INFORMATION, COMPLETE_SUBPROCESS_RUN)));
+    assertThat(action.isInternal().isPresent()).isTrue();
+    assertThat(action.isInternal().get()).isFalse();
+  }
+
+  @Test
+  public void isNotInternalRemotelyExecuted() {
+    var thread = new EventThreadBuilder(1, 1);
+    var action =
+        new LocalAction(
+            thread.actionProcessingAction("Creating symlink [...]", "ExecutableSymlink", 10, 20),
+            List.of(thread.related(1, CAT_REMOTE_ACTION_EXECUTION)));
+    assertThat(action.isInternal().isPresent()).isTrue();
+    assertThat(action.isInternal().get()).isFalse();
+  }
 }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NoCacheActionsSuggestionProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/suggestionproviders/NoCacheActionsSuggestionProviderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.engflow.bazel.invocation.analyzer.EventThreadBuilder;
 import com.engflow.bazel.invocation.analyzer.SuggestionOutput;
+import com.engflow.bazel.invocation.analyzer.bazelprofile.BazelProfileConstants;
 import com.engflow.bazel.invocation.analyzer.dataproviders.FlagValueExperimentalProfileIncludeTargetLabel;
 import com.engflow.bazel.invocation.analyzer.dataproviders.LocalActions;
 import com.engflow.bazel.invocation.analyzer.dataproviders.remoteexecution.RemoteCachingUsed;
@@ -108,6 +109,14 @@ public class NoCacheActionsSuggestionProviderTest extends SuggestionProviderUnit
             thread.actionProcessingAction(
                 "no RC check, local exec", "b", 20, DURATION_FOR_INCLUSION),
             List.of(thread.related(20, 2, CAT_LOCAL_ACTION_EXECUTION)));
+    var internalAction =
+        new LocalActions.LocalAction(
+            thread.actionProcessingAction(
+                "internal action, do not include",
+                BazelProfileConstants.MNEMONIC_BAZEL_WORKSPACE_STATUS_ACTION,
+                20,
+                10),
+            List.of());
     var actionWithoutRemoteCacheCheckRemote =
         new LocalActions.LocalAction(
             thread.actionProcessingAction(
@@ -118,6 +127,7 @@ public class NoCacheActionsSuggestionProviderTest extends SuggestionProviderUnit
         LocalActions.create(
             List.of(
                 actionWithRemoteCacheCheck,
+                internalAction,
                 actionWithoutRemoteCacheCheckLocal,
                 actionWithoutRemoteCacheCheckRemote));
 
@@ -132,6 +142,7 @@ public class NoCacheActionsSuggestionProviderTest extends SuggestionProviderUnit
         .contains(actionWithoutRemoteCacheCheckLocal.getAction().name);
     assertThat(suggestion.getRecommendation())
         .contains(actionWithoutRemoteCacheCheckRemote.getAction().name);
+    assertThat(suggestion.getRecommendation()).doesNotContain(internalAction.getAction().name);
     assertThat(suggestion.getRecommendation())
         .doesNotContain(actionWithRemoteCacheCheck.getAction().name);
     assertThat(suggestion.getCaveatList()).isEmpty();


### PR DESCRIPTION
The Bazel profile does not clearly mark "internal" actions (as reported at the end of a Bazel invocation), however some internal actions can be identified by their mnemonic.

Contributes to #133