### PR TITLE
[DataProvider] Simplify `RemoteCacheMetrics`

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetrics.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetrics.java
@@ -18,50 +18,28 @@ import com.engflow.bazel.invocation.analyzer.core.Datum;
 import com.engflow.bazel.invocation.analyzer.time.DurationUtil;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import java.time.Duration;
 
 /**
- * Metrics on remote caching, namely how much time was spent on cache checks, downloading outputs,
- * uploading outputs, and what percentage of actions were cached remotely.
+ * Metrics on the time spent interacting with a remote cache, namely time spent on cache checks,
+ * downloading outputs, and uploading outputs.
  *
- * <p>Note that Bazel does not differentiate between a remote cache configured via {@code
- * --disk_cache} or {@code --remote_cache}.
+ * <p>Note that events in Bazel profiles do not differentiate between a remote cache configured via
+ * {@code --disk_cache} or {@code --remote_cache}.
  */
 public class RemoteCacheMetrics implements Datum {
 
-  private final int cacheChecks;
-  private final int cacheMisses;
   private final Duration cacheCheckDuration;
   private final Duration downloadOutputsDuration;
   private final Duration uploadOutputsDuration;
 
-  private final float percentCachedRemotely;
-
-  RemoteCacheMetrics() {
-    this(0, 0, Duration.ZERO, Duration.ZERO, Duration.ZERO);
-  }
-
   RemoteCacheMetrics(
-      int cacheChecks,
-      int cacheMisses,
       Duration totalCacheCheckDuration,
       Duration downloadOutputsDuration,
       Duration uploadOutputsDuration) {
-    this.cacheChecks = cacheChecks;
-    this.cacheMisses = cacheMisses;
-    this.percentCachedRemotely = 100f * (cacheChecks - cacheMisses) / cacheChecks;
     this.cacheCheckDuration = Preconditions.checkNotNull(totalCacheCheckDuration);
     this.downloadOutputsDuration = Preconditions.checkNotNull(downloadOutputsDuration);
     this.uploadOutputsDuration = Preconditions.checkNotNull(uploadOutputsDuration);
-  }
-
-  public int getCacheChecks() {
-    return cacheChecks;
-  }
-
-  public int getCacheMisses() {
-    return cacheMisses;
   }
 
   public Duration getCacheCheckDuration() {
@@ -78,7 +56,7 @@ public class RemoteCacheMetrics implements Datum {
 
   @Override
   public boolean isEmpty() {
-    return cacheChecks == 0;
+    return false;
   }
 
   @Override
@@ -88,8 +66,8 @@ public class RemoteCacheMetrics implements Datum {
 
   @Override
   public String getDescription() {
-    return "Metrics on the remote caching used. This includes both the use of `--remote_cache` and"
-        + " `--disk_cache`.";
+    return "Metrics on the time spent interacting with a remote cache configured with"
+        + " `--remote_cache` or `--disk_cache`.";
   }
 
   @Override
@@ -106,39 +84,22 @@ public class RemoteCacheMetrics implements Datum {
       return false;
     }
     RemoteCacheMetrics that = (RemoteCacheMetrics) o;
-    return that.cacheChecks == cacheChecks
-        && that.cacheMisses == cacheMisses
-        && Float.compare(that.percentCachedRemotely, percentCachedRemotely) == 0
-        && Objects.equal(cacheCheckDuration, that.cacheCheckDuration)
+    return Objects.equal(cacheCheckDuration, that.cacheCheckDuration)
         && Objects.equal(downloadOutputsDuration, that.downloadOutputsDuration)
         && Objects.equal(uploadOutputsDuration, that.uploadOutputsDuration);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
-        cacheChecks,
-        cacheMisses,
-        percentCachedRemotely,
-        cacheCheckDuration,
-        downloadOutputsDuration,
-        uploadOutputsDuration);
+    return Objects.hashCode(cacheCheckDuration, downloadOutputsDuration, uploadOutputsDuration);
   }
 
   @Override
   public String getSummary() {
-    String formattedPercentage = String.format("%,.2f%%", percentCachedRemotely);
-    var width = Math.max(formattedPercentage.length(), String.valueOf(cacheChecks).length());
     return String.format(
-        "Number of cache checks:             %s\n"
-            + "Number of cache misses:             %s\n"
-            + "Cache hit percentage:               %s\n"
-            + "Time spend checking for cache hits: %s\n"
-            + "Time spend downloading outputs:     %s\n"
-            + "Time spend uploading outputs:       %s",
-        Strings.padStart(String.valueOf(cacheChecks), width, ' '),
-        Strings.padStart(String.valueOf(cacheMisses), width, ' '),
-        Strings.padStart(formattedPercentage, width, ' '),
+        "Remote cache checks:     %s\n"
+            + "Downloading outputs:     %s\n"
+            + "Uploading outputs:       %s",
         DurationUtil.formatDuration(cacheCheckDuration),
         DurationUtil.formatDuration(downloadOutputsDuration),
         DurationUtil.formatDuration(uploadOutputsDuration));

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProviderTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/dataproviders/RemoteCacheMetricsDataProviderTest.java
@@ -56,8 +56,9 @@ public class RemoteCacheMetricsDataProviderTest extends DataProviderUnitTestBase
     useProfile(metaData(), trace(mainThread()));
     when(dataManager.getDatum(LocalActions.class)).thenReturn(LocalActions.create(List.of()));
 
-    assertThat(provider.derive().isEmpty()).isTrue();
-    assertThat(provider.derive().getEmptyReason()).isNotNull();
+    assertThat(provider.derive().getCacheCheckDuration()).isEqualTo(Duration.ZERO);
+    assertThat(provider.derive().getDownloadOutputsDuration()).isEqualTo(Duration.ZERO);
+    assertThat(provider.derive().getUploadOutputsDuration()).isEqualTo(Duration.ZERO);
   }
 
   @Test
@@ -105,10 +106,6 @@ public class RemoteCacheMetricsDataProviderTest extends DataProviderUnitTestBase
     Truth.assertThat(provider.derive())
         .isEqualTo(
             new RemoteCacheMetrics(
-                3,
-                2,
-                Duration.ofSeconds(1 + 4 + 8),
-                Duration.ofSeconds(2),
-                Duration.ofSeconds(3 + 7)));
+                Duration.ofSeconds(1 + 4 + 8), Duration.ofSeconds(2), Duration.ofSeconds(3 + 7)));
   }
 }


### PR DESCRIPTION
Both `RemoteCacheMetrics` and `CachingAndExecutionMetrics` estimate the number of cache checks and cache misses/hits. This change removes the analysis from `RemoteCacheMetrics`, as `CachingAndExecutionMetrics` seems to extract more precise data.

Fixes #156