### PR TITLE
[Performance] Use interner to de-duplicate strings

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/CompleteEvent.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/CompleteEvent.java
@@ -22,7 +22,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
 import java.time.Duration;
-import java.util.Map.Entry;
 import javax.annotation.Nullable;
 
 public class CompleteEvent {
@@ -38,10 +37,10 @@ public class CompleteEvent {
   public CompleteEvent(JsonObject object) {
     this(
         object.has(TraceEventFormatConstants.EVENT_NAME)
-            ? object.get(TraceEventFormatConstants.EVENT_NAME).getAsString()
+            ? object.get(TraceEventFormatConstants.EVENT_NAME).getAsString().intern()
             : null,
         object.has(TraceEventFormatConstants.EVENT_CATEGORY)
-            ? object.get(TraceEventFormatConstants.EVENT_CATEGORY).getAsString()
+            ? object.get(TraceEventFormatConstants.EVENT_CATEGORY).getAsString().intern()
             : null,
         Timestamp.ofMicros(object.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong()),
         TimeUtil.getDurationForMicros(
@@ -54,7 +53,9 @@ public class CompleteEvent {
                 .getAsJsonObject()
                 .entrySet()
                 .stream()
-                .collect(toImmutableMap(Entry::getKey, e1 -> e1.getValue().getAsString()))
+                .collect(
+                    toImmutableMap(
+                        e -> e.getKey().intern(), e -> e.getValue().getAsString().intern()))
             : ImmutableMap.of());
   }
 

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/CounterEvent.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/CounterEvent.java
@@ -24,7 +24,7 @@ public class CounterEvent {
   private final double totalValue;
 
   public CounterEvent(JsonObject event) {
-    this.name = event.get(TraceEventFormatConstants.EVENT_NAME).getAsString();
+    this.name = event.get(TraceEventFormatConstants.EVENT_NAME).getAsString().intern();
     this.timestamp =
         Timestamp.ofMicros(event.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong());
 

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/InstantEvent.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/InstantEvent.java
@@ -24,8 +24,8 @@ public class InstantEvent {
   private final Timestamp timestamp;
 
   public InstantEvent(JsonObject event) {
-    this.category = event.get(TraceEventFormatConstants.EVENT_CATEGORY).getAsString();
-    this.name = event.get(TraceEventFormatConstants.EVENT_NAME).getAsString();
+    this.category = event.get(TraceEventFormatConstants.EVENT_CATEGORY).getAsString().intern();
+    this.name = event.get(TraceEventFormatConstants.EVENT_NAME).getAsString().intern();
     this.timestamp =
         Timestamp.ofMicros(event.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong());
   }


### PR DESCRIPTION
When reading the profile, many strings are encountered multiple times. Use `String.interner()` to reduce the memory requirements of running the analyzer.

Benchmark with a Bazel profile of unzipped size 357MB Using YourKit as a profiler and checking the shallow size just before generating the suggestions:

Before: 692 MB
After:  349 MB

Progress on #163 