### PR TITLE
Fix minor typo in the tip to leave `--jobs` unset

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/JobsSuggestionProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/suggestionproviders/JobsSuggestionProvider.java
@@ -78,7 +78,7 @@ public class JobsSuggestionProvider extends SuggestionProviderBase {
           return SuggestionProviderUtil.createSuggestionOutputForEmptyInput(
               ANALYZER_CLASSNAME, EMPTY_REASON_PREFIX + coresUsed.getEmptyReason());
         }
-        String title = "Unset the value of of the Bazel flag --jobs";
+        String title = "Unset the value of the Bazel flag --jobs";
         String recommendation =
             "For local builds, setting the Bazel flag --jobs to a number is not"
                 + " recommended. Instead, omit this flag or set the value to \"auto\".\n"


### PR DESCRIPTION
The present change aims at removing the redundant `of` in the suggested improvement to leave the `--jobs` flags unset:
- CLI:
  ![image](https://github.com/EngFlow/bazel_invocation_analyzer/assets/7901596/038f6986-8ea3-4efb-b917-2cf4170e034e)
- UI:
  ![image](https://github.com/EngFlow/bazel_invocation_analyzer/assets/7901596/d74a5218-776f-4198-b39f-2e2162f864b8)
```patch
-Unset the value of of the Bazel flag --jobs
+Unset the value of the Bazel flag --jobs
```