### PR TITLE
[Core] Avoid NPEs on creating events

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
@@ -117,14 +117,14 @@ public class ProfileThread {
       switch (event.get(TraceEventFormatConstants.EVENT_PHASE).getAsString()) {
         case TraceEventFormatConstants.PHASE_COMPLETE: // Complete events
           {
-            completeEvents.add(new CompleteEvent(event));
+            completeEvents.add(CompleteEvent.fromJson(event));
             break;
           }
 
         case "I": // Deprecated, fall-through
         case TraceEventFormatConstants.PHASE_INSTANT: // Instant events
           {
-            InstantEvent instantEvent = new InstantEvent(event);
+            InstantEvent instantEvent = InstantEvent.fromJson(event);
 
             List<InstantEvent> instantList =
                 instants.compute(
@@ -142,7 +142,7 @@ public class ProfileThread {
 
         case TraceEventFormatConstants.PHASE_COUNTER: // Counter events
           {
-            CounterEvent counterEvent = new CounterEvent(event);
+            CounterEvent counterEvent = CounterEvent.fromJson(event);
 
             List<CounterEvent> countList =
                 counts.compute(

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/CounterEvent.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/CounterEvent.java
@@ -15,25 +15,78 @@
 package com.engflow.bazel.invocation.analyzer.traceeventformat;
 
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.gson.JsonObject;
+import java.util.Arrays;
+import java.util.List;
 
+/**
+ * Counter events can track a value or multiple values as they change over time.
+ *
+ * @see <a
+ *     href="https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.msg3086636uq">specification</a>
+ */
 public class CounterEvent {
+  @VisibleForTesting
+  static final List<String> REQUIRED_JSON_MEMBERS =
+      List.of(
+          TraceEventFormatConstants.EVENT_NAME,
+          TraceEventFormatConstants.EVENT_TIMESTAMP,
+          TraceEventFormatConstants.EVENT_ARGUMENTS);
+
   private final String name;
   private final Timestamp timestamp;
   private final double totalValue;
 
-  public CounterEvent(JsonObject event) {
-    this.name = event.get(TraceEventFormatConstants.EVENT_NAME).getAsString().intern();
-    this.timestamp =
-        Timestamp.ofMicros(event.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong());
+  public static CounterEvent fromJson(JsonObject event) {
+    List<String> missingMembers = Lists.newArrayList();
+    for (String requiredMember : REQUIRED_JSON_MEMBERS) {
+      if (!event.has(requiredMember)) {
+        missingMembers.add(requiredMember);
+      }
+    }
+    if (!missingMembers.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Missing members: " + Arrays.toString(missingMembers.toArray()));
+    }
 
     // For now we are treating all the different counts as a single metric by summing them
     // together. In the future we may want to respect each count individually.
-    this.totalValue =
+    var totalValue =
         event.get(TraceEventFormatConstants.EVENT_ARGUMENTS).getAsJsonObject().entrySet().stream()
             .mapToDouble(e -> e.getValue().getAsDouble())
             .sum();
+
+    return new CounterEvent(
+        event.get(TraceEventFormatConstants.EVENT_NAME).getAsString(),
+        Timestamp.ofMicros(event.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong()),
+        totalValue);
+  }
+
+  /**
+   * Parses a {@link CounterEvent} from a JsonObject.
+   *
+   * @deprecated Use {@link #fromJson(JsonObject)} instead.
+   */
+  @Deprecated
+  public CounterEvent(JsonObject event) {
+    this(
+        event.get(TraceEventFormatConstants.EVENT_NAME).getAsString(),
+        Timestamp.ofMicros(event.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong()),
+        // For now we are treating all the different counts as a single metric by summing them
+        // together. In the future we may want to respect each count individually.
+        event.get(TraceEventFormatConstants.EVENT_ARGUMENTS).getAsJsonObject().entrySet().stream()
+            .mapToDouble(e -> e.getValue().getAsDouble())
+            .sum());
+  }
+
+  private CounterEvent(String name, Timestamp timestamp, double totalValue) {
+    this.name = Preconditions.checkNotNull(name).intern();
+    this.timestamp = Preconditions.checkNotNull(timestamp);
+    this.totalValue = totalValue;
   }
 
   public String getName() {

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/InstantEvent.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat/InstantEvent.java
@@ -15,19 +15,67 @@
 package com.engflow.bazel.invocation.analyzer.traceeventformat;
 
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.gson.JsonObject;
+import java.util.Arrays;
+import java.util.List;
 
+/**
+ * Instant events describe an event that has no duration.
+ *
+ * @see <a
+ *     https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.lenwiilchoxp">specification</a>
+ */
 public class InstantEvent {
+  @VisibleForTesting
+  static final List<String> REQUIRED_JSON_MEMBERS =
+      List.of(
+          TraceEventFormatConstants.EVENT_CATEGORY,
+          TraceEventFormatConstants.EVENT_NAME,
+          TraceEventFormatConstants.EVENT_TIMESTAMP);
+
   private final String category;
   private final String name;
   private final Timestamp timestamp;
 
+  public static InstantEvent fromJson(JsonObject event) {
+    List<String> missingMembers = Lists.newArrayList();
+    for (String requiredMember : REQUIRED_JSON_MEMBERS) {
+      if (!event.has(requiredMember)) {
+        missingMembers.add(requiredMember);
+      }
+    }
+    if (!missingMembers.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Missing members: " + Arrays.toString(missingMembers.toArray()));
+    }
+
+    return new InstantEvent(
+        event.get(TraceEventFormatConstants.EVENT_CATEGORY).getAsString(),
+        event.get(TraceEventFormatConstants.EVENT_NAME).getAsString(),
+        Timestamp.ofMicros(event.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong()));
+  }
+
+  /**
+   * Parses a {@link InstantEvent} from a JsonObject.
+   *
+   * @deprecated Use {@link #fromJson(JsonObject)} instead.
+   */
+  @Deprecated
   public InstantEvent(JsonObject event) {
-    this.category = event.get(TraceEventFormatConstants.EVENT_CATEGORY).getAsString().intern();
-    this.name = event.get(TraceEventFormatConstants.EVENT_NAME).getAsString().intern();
-    this.timestamp =
-        Timestamp.ofMicros(event.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong());
+    this(
+        event.get(TraceEventFormatConstants.EVENT_CATEGORY).getAsString(),
+        event.get(TraceEventFormatConstants.EVENT_NAME).getAsString(),
+        Timestamp.ofMicros(event.get(TraceEventFormatConstants.EVENT_TIMESTAMP).getAsLong()));
+  }
+
+  private InstantEvent(String category, String name, Timestamp timestamp) {
+    this.category = Preconditions.checkNotNull(category).intern();
+    this.name = Preconditions.checkNotNull(name).intern();
+    this.timestamp = Preconditions.checkNotNull(timestamp);
   }
 
   public String getCategory() {

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/BUILD
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/BUILD
@@ -1,0 +1,12 @@
+java_test(
+    name = "traceeventformat",
+    srcs = glob(["**/*.java"]),
+    test_class = "com.engflow.bazel.invocation.analyzer.traceeventformat.TraceEventFormatTestSuite",
+    deps = [
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
+        "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",
+        "//third_party/gson",
+        "//third_party/junit",
+        "//third_party/truth",
+    ],
+)

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/CompleteEventTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/CompleteEventTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.traceeventformat;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.engflow.bazel.invocation.analyzer.time.TimeUtil;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+public class CompleteEventTest {
+  @Test
+  public void fromJsonThrowsOnMissingMembers() {
+    var jsonObject = new JsonObject();
+    var e = assertThrows(IllegalArgumentException.class, () -> CompleteEvent.fromJson(jsonObject));
+    for (var member : CompleteEvent.REQUIRED_JSON_MEMBERS) {
+      assertThat(e.getMessage()).contains(member);
+    }
+  }
+
+  @Test
+  public void fromJsonMinimal() {
+    var jsonObject = new JsonObject();
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_TIMESTAMP, 123_456_789);
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_DURATION, 456_789);
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_THREAD_ID, 42);
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_PROCESS_ID, 765);
+
+    var event = CompleteEvent.fromJson(jsonObject);
+    assertThat(event.name).isNull();
+    assertThat(event.category).isNull();
+    assertThat(event.start.getMicros()).isEqualTo(123_456_789);
+    assertThat(TimeUtil.getMicros(event.duration)).isEqualTo(456_789);
+    assertThat(event.threadId).isEqualTo(42);
+    assertThat(event.processId).isEqualTo(765);
+    assertThat(event.args).isEmpty();
+  }
+
+  @Test
+  public void fromJsonAll() {
+    var jsonObject = new JsonObject();
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_NAME, "fooName");
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_CATEGORY, "fooCat");
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_TIMESTAMP, 123_456_789);
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_DURATION, 456_789);
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_THREAD_ID, 42);
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_PROCESS_ID, 765);
+
+    var args = new JsonObject();
+    args.addProperty("argFooKey", "argFooVal");
+    args.addProperty("argBarKey", "argBarVal");
+    jsonObject.add(TraceEventFormatConstants.EVENT_ARGUMENTS, args);
+
+    var event = CompleteEvent.fromJson(jsonObject);
+    assertThat(event.name).isEqualTo("fooName");
+    assertThat(event.category).isEqualTo("fooCat");
+    assertThat(event.start.getMicros()).isEqualTo(123_456_789);
+    assertThat(TimeUtil.getMicros(event.duration)).isEqualTo(456_789);
+    assertThat(event.threadId).isEqualTo(42);
+    assertThat(event.processId).isEqualTo(765);
+    assertThat(event.args).hasSize(2);
+    assertThat(event.args).containsEntry("argFooKey", "argFooVal");
+    assertThat(event.args).containsEntry("argBarKey", "argBarVal");
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/CounterEventTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/CounterEventTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.traceeventformat;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+public class CounterEventTest {
+  @Test
+  public void fromJsonThrowsOnMissingMembers() {
+    var jsonObject = new JsonObject();
+    var e = assertThrows(IllegalArgumentException.class, () -> CounterEvent.fromJson(jsonObject));
+    for (var member : CounterEvent.REQUIRED_JSON_MEMBERS) {
+      assertThat(e.getMessage()).contains(member);
+    }
+  }
+
+  @Test
+  public void fromJson() {
+    var jsonObject = new JsonObject();
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_NAME, "someEventName");
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_TIMESTAMP, 1_234_567_890);
+
+    var args = new JsonObject();
+    args.addProperty("argFooKey", 1.23);
+    args.addProperty("argBarKey", 3.45);
+    jsonObject.add(TraceEventFormatConstants.EVENT_ARGUMENTS, args);
+
+    var event = CounterEvent.fromJson(jsonObject);
+    assertThat(event.getName()).isEqualTo("someEventName");
+    assertThat(event.getTimestamp().getMicros()).isEqualTo(1_234_567_890);
+    assertThat(event.getTotalValue()).isEqualTo(1.23 + 3.45);
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/InstantEventTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/InstantEventTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.traceeventformat;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+public class InstantEventTest {
+  @Test
+  public void fromJsonThrowsOnMissingMembers() {
+    var jsonObject = new JsonObject();
+    var e = assertThrows(IllegalArgumentException.class, () -> InstantEvent.fromJson(jsonObject));
+    for (var member : InstantEvent.REQUIRED_JSON_MEMBERS) {
+      assertThat(e.getMessage()).contains(member);
+    }
+  }
+
+  @Test
+  public void fromJson() {
+    var jsonObject = new JsonObject();
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_CATEGORY, "someCategory");
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_NAME, "someEventName");
+    jsonObject.addProperty(TraceEventFormatConstants.EVENT_TIMESTAMP, 987_654_321);
+
+    var event = InstantEvent.fromJson(jsonObject);
+    assertThat(event.getName()).isEqualTo("someEventName");
+    assertThat(event.getCategory()).isEqualTo("someCategory");
+    assertThat(event.getTimestamp().getMicros()).isEqualTo(987_654_321);
+  }
+}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/TraceEventFormatTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/TraceEventFormatTestSuite.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 EngFlow Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.engflow.bazel.invocation.analyzer.traceeventformat;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+  CompleteEventTest.class,
+  CounterEventTest.class,
+  InstantEventTest.class,
+})
+public class TraceEventFormatTestSuite {}

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/TraceEventFormatTestSuite.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/traceeventformat/TraceEventFormatTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 EngFlow Inc.
+ * Copyright 2024 EngFlow Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
When creating trace event format events, the code used to throw NullPointerExceptions when trying to construct an event from a JsonObject that was missing required members.

This change adds static `fromJson` methods, which check the members exist, or otherwise throw an IllegalArgumentException. This better communicates the kind of error that occurred - the provided Json did not have the expected form.
This change also adds some basic documentation and tests for the Event classes.