### PR TITLE
Reduce complexity of CriticalPathQueuingDurationDataProvider

### DIFF
--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
@@ -35,6 +35,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -80,6 +81,10 @@ public class BazelProfile implements Datum {
       throws IllegalArgumentException {
     return new BazelProfile(
         new JsonReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)));
+  }
+
+  public static BazelProfile of(Reader reader) {
+    return new BazelProfile(new JsonReader(reader));
   }
 
   private final BazelVersion bazelVersion;

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
@@ -152,7 +152,7 @@ public class BazelProfile implements Datum {
       }
       threads =
           threadBuilders.entrySet().stream()
-              .collect(Collectors.toConcurrentMap(Map.Entry::getKey, e -> e.getValue().build()));
+              .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().build()));
     } catch (IllegalStateException | IOException e) {
       throw new IllegalArgumentException("Could not parse Bazel profile.", e);
     }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfile.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipException;
@@ -89,10 +90,11 @@ public class BazelProfile implements Datum {
 
   private final BazelVersion bazelVersion;
   private final Map<String, String> otherData = new HashMap<>();
-  private final Map<ThreadId, ProfileThread> threads = new HashMap<>();
+  private final Map<ThreadId, ProfileThread> threads;
 
   private BazelProfile(JsonReader profileReader) {
     try {
+      Map<ThreadId, ProfileThread.Builder> threadBuilders = new HashMap<>();
       boolean hasOtherData = false;
       boolean hasTraceEvents = false;
       profileReader.beginObject();
@@ -121,17 +123,17 @@ public class BazelProfile implements Datum {
                 continue;
               }
               ThreadId threadId = new ThreadId(pid, tid);
-              ProfileThread profileThread =
-                  threads.compute(
+              ProfileThread.Builder profileThreadBuilder =
+                  threadBuilders.compute(
                       threadId,
                       (key, t) -> {
                         if (t == null) {
-                          t = new ProfileThread(threadId);
+                          t = new ProfileThread.Builder().setThreadId(key);
                         }
                         return t;
                       });
               // TODO: Use success response to take action on errant events.
-              profileThread.addEvent(traceEvent);
+              profileThreadBuilder.addEvent(traceEvent);
             }
             profileReader.endArray();
             break;
@@ -148,6 +150,9 @@ public class BazelProfile implements Datum {
                 TraceEventFormatConstants.SECTION_OTHER_DATA,
                 TraceEventFormatConstants.SECTION_TRACE_EVENTS));
       }
+      threads =
+          threadBuilders.entrySet().stream()
+              .collect(Collectors.toConcurrentMap(Map.Entry::getKey, e -> e.getValue().build()));
     } catch (IllegalStateException | IOException e) {
       throw new IllegalArgumentException("Could not parse Bazel profile.", e);
     }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
@@ -112,8 +112,14 @@ public class ProfileThread {
   /**
    * Parses a {@link JsonObject} as a tracing event and adds it to this thread. Returns {@code true}
    * if parsing and adding the event was successful and {@code false} otherwise.
+   *
+   * @throws IllegalStateException if the thread has already been sorted, and as such cannot be
+   *     modified anymore.
    */
   public boolean addEvent(JsonObject event) {
+    if (sorted) {
+      throw new IllegalStateException("Cannot add event, Bazel profile thread has been sorted!");
+    }
     try {
       switch (event.get(TraceEventFormatConstants.EVENT_PHASE).getAsString()) {
         case TraceEventFormatConstants.PHASE_COMPLETE: // Complete events

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
@@ -40,25 +40,12 @@ public class ProfileThread {
 
   @Nullable private String name;
   @Nullable private Integer sortIndex;
-  private boolean sorted;
 
-  private final List<JsonObject> extraMetadata;
-  private final List<JsonObject> extraEvents;
-  private final List<CompleteEvent> completeEvents;
-  private final Map<String, List<CounterEvent>> counts;
-  private final Map<String, List<InstantEvent>> instants;
-
-  public ProfileThread(ThreadId threadId) {
-    this(
-        threadId,
-        null,
-        null,
-        new ArrayList<>(),
-        new ArrayList<>(),
-        new ArrayList<>(),
-        new HashMap<>(),
-        new HashMap<>());
-  }
+  private final ImmutableList<JsonObject> extraMetadata;
+  private final ImmutableList<JsonObject> extraEvents;
+  private final ImmutableList<CompleteEvent> completeEvents;
+  private final ImmutableMap<String, ImmutableList<CounterEvent>> counts;
+  private final ImmutableMap<String, ImmutableList<InstantEvent>> instants;
 
   @Override
   public String toString() {
@@ -76,23 +63,23 @@ public class ProfileThread {
         threadId, name, sortIndex, extraMetadata, extraEvents, completeEvents, counts, instants);
   }
 
-  public ProfileThread(
+  private ProfileThread(
       ThreadId threadId,
       @Nullable String name,
       @Nullable Integer sortIndex,
-      @Nullable List<JsonObject> extraMetadata,
-      @Nullable List<JsonObject> extraEvents,
-      @Nullable List<CompleteEvent> completeEvents,
-      @Nullable Map<String, List<CounterEvent>> counts,
-      @Nullable Map<String, List<InstantEvent>> instants) {
+      @Nullable ImmutableList<JsonObject> extraMetadata,
+      @Nullable ImmutableList<JsonObject> extraEvents,
+      @Nullable ImmutableList<CompleteEvent> completeEvents,
+      @Nullable ImmutableMap<String, ImmutableList<CounterEvent>> counts,
+      @Nullable ImmutableMap<String, ImmutableList<InstantEvent>> instants) {
     this.threadId = Preconditions.checkNotNull(threadId);
     this.name = name;
     this.sortIndex = sortIndex;
-    this.extraMetadata = extraMetadata == null ? new ArrayList<>() : extraMetadata;
-    this.extraEvents = extraEvents == null ? new ArrayList<>() : extraEvents;
-    this.completeEvents = completeEvents == null ? new ArrayList<>() : completeEvents;
-    this.counts = counts == null ? new HashMap<>() : counts;
-    this.instants = instants == null ? new HashMap<>() : instants;
+    this.extraMetadata = extraMetadata == null ? ImmutableList.of() : extraMetadata;
+    this.extraEvents = extraEvents == null ? ImmutableList.of() : extraEvents;
+    this.completeEvents = completeEvents == null ? ImmutableList.of() : completeEvents;
+    this.counts = counts == null ? ImmutableMap.of() : counts;
+    this.instants = instants == null ? ImmutableMap.of() : instants;
   }
 
   public ThreadId getThreadId() {
@@ -109,135 +96,20 @@ public class ProfileThread {
     return sortIndex;
   }
 
-  /**
-   * Parses a {@link JsonObject} as a tracing event and adds it to this thread. Returns {@code true}
-   * if parsing and adding the event was successful and {@code false} otherwise.
-   *
-   * @throws IllegalStateException if the thread has already been sorted, and as such cannot be
-   *     modified anymore.
-   */
-  public boolean addEvent(JsonObject event) {
-    if (sorted) {
-      throw new IllegalStateException("Cannot add event, Bazel profile thread has been sorted!");
-    }
-    try {
-      switch (event.get(TraceEventFormatConstants.EVENT_PHASE).getAsString()) {
-        case TraceEventFormatConstants.PHASE_COMPLETE: // Complete events
-          {
-            completeEvents.add(CompleteEvent.fromJson(event));
-            break;
-          }
-
-        case "I": // Deprecated, fall-through
-        case TraceEventFormatConstants.PHASE_INSTANT: // Instant events
-          {
-            InstantEvent instantEvent = InstantEvent.fromJson(event);
-
-            List<InstantEvent> instantList =
-                instants.compute(
-                    instantEvent.getCategory(),
-                    (key, c) -> {
-                      if (c == null) {
-                        c = new ArrayList<>();
-                      }
-                      return c;
-                    });
-
-            instantList.add(instantEvent);
-            break;
-          }
-
-        case TraceEventFormatConstants.PHASE_COUNTER: // Counter events
-          {
-            CounterEvent counterEvent = CounterEvent.fromJson(event);
-
-            List<CounterEvent> countList =
-                counts.compute(
-                    counterEvent.getName(),
-                    (key, c) -> {
-                      if (c == null) {
-                        c = new ArrayList<>();
-                      }
-                      return c;
-                    });
-
-            countList.add(counterEvent);
-            break;
-          }
-
-        case TraceEventFormatConstants.PHASE_METADATA: // Metadata events
-          {
-            String eventName = event.get(TraceEventFormatConstants.EVENT_NAME).getAsString();
-            if (TraceEventFormatConstants.METADATA_THREAD_NAME.equals(eventName)) {
-              this.name =
-                  event
-                      .get(TraceEventFormatConstants.EVENT_ARGUMENTS)
-                      .getAsJsonObject()
-                      .get("name")
-                      .getAsString();
-            } else if (TraceEventFormatConstants.METADATA_THREAD_SORT_INDEX.equals(eventName)) {
-              this.sortIndex =
-                  Integer.parseInt(
-                      event
-                          .get(TraceEventFormatConstants.EVENT_ARGUMENTS)
-                          .getAsJsonObject()
-                          .get("sort_index")
-                          .getAsString());
-            } else {
-              extraMetadata.add(event);
-            }
-            break;
-          }
-
-        default:
-          extraEvents.add(event);
-      }
-
-      return true;
-    } catch (Exception ex) {
-      return false;
-    }
-  }
-
   public List<CompleteEvent> getCompleteEvents() {
-    synchronized (this) {
-      if (!sorted) {
-        completeEvents.sort(Comparator.comparing((e) -> e.start));
-        sorted = true;
-      }
-    }
     return completeEvents;
   }
 
   public ImmutableMap<String, ImmutableList<CounterEvent>> getCounts() {
-    return ImmutableMap.copyOf(
-        counts.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    e -> {
-                      List<CounterEvent> entries = e.getValue();
-                      entries.sort(Comparator.comparing(CounterEvent::getTimestamp));
-                      return ImmutableList.copyOf(entries);
-                    })));
+    return counts;
   }
 
   public ImmutableMap<String, ImmutableList<InstantEvent>> getInstants() {
-    return ImmutableMap.copyOf(
-        instants.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    e -> {
-                      List<InstantEvent> entries = e.getValue();
-                      entries.sort(Comparator.comparing(InstantEvent::getTimestamp));
-                      return ImmutableList.copyOf(entries);
-                    })));
+    return instants;
   }
 
   public ImmutableList<JsonObject> getExtraEvents() {
-    extraEvents.sort(Comparator.comparingLong(e -> e.get("ts").getAsLong()));
-    return ImmutableList.copyOf(extraEvents);
+    return extraEvents;
   }
 
   @Override
@@ -269,5 +141,216 @@ public class ProfileThread {
   public int hashCode() {
     return Objects.hashCode(
         threadId, name, sortIndex, extraMetadata, extraEvents, completeEvents, counts, instants);
+  }
+
+  public static class Builder {
+
+    private ThreadId threadId;
+
+    @Nullable private String name;
+    @Nullable private Integer sortIndex;
+
+    private List<JsonObject> extraMetadata = new ArrayList<>();
+    private List<JsonObject> extraEvents = new ArrayList<>();
+    private List<CompleteEvent> completeEvents = new ArrayList<>();
+    private Map<String, List<CounterEvent>> counts = new HashMap<>();
+    private Map<String, List<InstantEvent>> instants = new HashMap<>();
+
+    /**
+     * Parses a {@link JsonObject} as a tracing event and adds it to this thread. Returns {@code
+     * true} if parsing and adding the event was successful and {@code false} otherwise.
+     */
+    public boolean addEvent(JsonObject event) {
+      try {
+        switch (event.get(TraceEventFormatConstants.EVENT_PHASE).getAsString()) {
+          case TraceEventFormatConstants.PHASE_COMPLETE: // Complete events
+            {
+              completeEvents.add(CompleteEvent.fromJson(event));
+              break;
+            }
+
+          case "I": // Deprecated, fall-through
+          case TraceEventFormatConstants.PHASE_INSTANT: // Instant events
+            {
+              InstantEvent instantEvent = InstantEvent.fromJson(event);
+
+              List<InstantEvent> instantList =
+                  instants.compute(
+                      instantEvent.getCategory(),
+                      (key, c) -> {
+                        if (c == null) {
+                          c = new ArrayList<>();
+                        }
+                        return c;
+                      });
+
+              instantList.add(instantEvent);
+              break;
+            }
+
+          case TraceEventFormatConstants.PHASE_COUNTER: // Counter events
+            {
+              CounterEvent counterEvent = CounterEvent.fromJson(event);
+
+              List<CounterEvent> countList =
+                  counts.compute(
+                      counterEvent.getName(),
+                      (key, c) -> {
+                        if (c == null) {
+                          c = new ArrayList<>();
+                        }
+                        return c;
+                      });
+
+              countList.add(counterEvent);
+              break;
+            }
+
+          case TraceEventFormatConstants.PHASE_METADATA: // Metadata events
+            {
+              String eventName = event.get(TraceEventFormatConstants.EVENT_NAME).getAsString();
+              if (TraceEventFormatConstants.METADATA_THREAD_NAME.equals(eventName)) {
+                this.name =
+                    event
+                        .get(TraceEventFormatConstants.EVENT_ARGUMENTS)
+                        .getAsJsonObject()
+                        .get("name")
+                        .getAsString();
+              } else if (TraceEventFormatConstants.METADATA_THREAD_SORT_INDEX.equals(eventName)) {
+                this.sortIndex =
+                    Integer.parseInt(
+                        event
+                            .get(TraceEventFormatConstants.EVENT_ARGUMENTS)
+                            .getAsJsonObject()
+                            .get("sort_index")
+                            .getAsString());
+              } else {
+                extraMetadata.add(event);
+              }
+              break;
+            }
+
+          default:
+            extraEvents.add(event);
+        }
+
+        return true;
+      } catch (Exception ex) {
+        return false;
+      }
+    }
+
+    public ThreadId getThreadId() {
+      return threadId;
+    }
+
+    public Builder setThreadId(ThreadId threadId) {
+      this.threadId = threadId;
+      return this;
+    }
+
+    @Nullable
+    public String getName() {
+      return name;
+    }
+
+    public Builder setName(@Nullable String name) {
+      this.name = name;
+      return this;
+    }
+
+    @Nullable
+    public Integer getSortIndex() {
+      return sortIndex;
+    }
+
+    public Builder setSortIndex(@Nullable Integer sortIndex) {
+      this.sortIndex = sortIndex;
+      return this;
+    }
+
+    public List<JsonObject> getExtraMetadata() {
+      return extraMetadata;
+    }
+
+    public Builder setExtraMetadata(List<JsonObject> extraMetadata) {
+      this.extraMetadata = extraMetadata;
+      return this;
+    }
+
+    public List<JsonObject> getExtraEvents() {
+      return extraEvents;
+    }
+
+    public Builder setExtraEvents(List<JsonObject> extraEvents) {
+      this.extraEvents = extraEvents;
+      return this;
+    }
+
+    public List<CompleteEvent> getCompleteEvents() {
+      return completeEvents;
+    }
+
+    public Builder setCompleteEvents(List<CompleteEvent> completeEvents) {
+      this.completeEvents = completeEvents;
+      return this;
+    }
+
+    public Map<String, List<CounterEvent>> getCounts() {
+      return counts;
+    }
+
+    public Builder setCounts(Map<String, List<CounterEvent>> counts) {
+      this.counts = counts;
+      return this;
+    }
+
+    public Map<String, List<InstantEvent>> getInstants() {
+      return instants;
+    }
+
+    public Builder setInstants(Map<String, List<InstantEvent>> instants) {
+      this.instants = instants;
+      return this;
+    }
+
+    public ProfileThread build() {
+      var extraEventsSorted =
+          ImmutableList.sortedCopyOf(
+              Comparator.comparingLong(e -> e.get("ts").getAsLong()), this.extraEvents);
+      var completeEventSorted =
+          ImmutableList.sortedCopyOf(Comparator.comparing((e) -> e.start), this.completeEvents);
+      var countsSorted =
+          ImmutableMap.copyOf(
+              counts.entrySet().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Map.Entry::getKey,
+                          e -> {
+                            List<CounterEvent> entries = e.getValue();
+                            entries.sort(Comparator.comparing(CounterEvent::getTimestamp));
+                            return ImmutableList.copyOf(entries);
+                          })));
+      var instantsSorted =
+          ImmutableMap.copyOf(
+              instants.entrySet().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Map.Entry::getKey,
+                          e -> {
+                            List<InstantEvent> entries = e.getValue();
+                            entries.sort(Comparator.comparing(InstantEvent::getTimestamp));
+                            return ImmutableList.copyOf(entries);
+                          })));
+      return new ProfileThread(
+          this.threadId,
+          this.name,
+          this.sortIndex,
+          ImmutableList.copyOf(this.extraMetadata),
+          extraEventsSorted,
+          completeEventSorted,
+          countsSorted,
+          instantsSorted);
+    }
   }
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
@@ -40,6 +40,7 @@ public class ProfileThread {
 
   @Nullable private String name;
   @Nullable private Integer sortIndex;
+  private boolean sorted;
 
   private final List<JsonObject> extraMetadata;
   private final List<JsonObject> extraEvents;
@@ -193,8 +194,13 @@ public class ProfileThread {
   }
 
   public List<CompleteEvent> getCompleteEvents() {
-    completeEvents.sort(Comparator.comparing((e) -> e.start));
-    return ImmutableList.copyOf(completeEvents);
+    synchronized (this) {
+      if (!sorted) {
+        completeEvents.sort(Comparator.comparing((e) -> e.start));
+        sorted = true;
+      }
+    }
+    return completeEvents;
   }
 
   public ImmutableMap<String, ImmutableList<CounterEvent>> getCounts() {

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/bazelprofile/ProfileThread.java
@@ -38,8 +38,8 @@ import javax.annotation.Nullable;
 public class ProfileThread {
   private final ThreadId threadId;
 
-  @Nullable private String name;
-  @Nullable private Integer sortIndex;
+  @Nullable private final String name;
+  @Nullable private final Integer sortIndex;
 
   private final ImmutableList<JsonObject> extraMetadata;
   private final ImmutableList<JsonObject> extraEvents;

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/BUILD
@@ -24,6 +24,7 @@ java_library(
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",
         "//third_party/guava",
+        "//third_party/jsr305",
     ],
 )
 

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
@@ -152,10 +152,11 @@ public class CriticalPathQueuingDurationDataProvider extends DataProvider {
             && cPathEvent.start.compareTo(event.start) <= 0) {
           continue;
         }
+        // Keep this always-false-condition for documentation purposes!
         // We have found cases where the end time of the critical path event is less than the end
         // time of the processing event. This might be a bug / inconsistency in Bazel profile
         // writing.
-        if (!cPathEvent.end.almostEquals(event.end) && cPathEvent.end.compareTo(event.end) <= 0) {
+        if (false && (!cPathEvent.end.almostEquals(event.end) && cPathEvent.end.compareTo(event.end) <= 0)) {
           continue;
         }
 

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
@@ -26,12 +26,14 @@ import com.engflow.bazel.invocation.analyzer.time.TimeUtil;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import com.engflow.bazel.invocation.analyzer.traceeventformat.CompleteEvent;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.HashMultimap;
 import java.time.Duration;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /**
  * A {@link DataProvider} that supplies the duration spent queuing for remote execution within the
@@ -60,110 +62,174 @@ public class CriticalPathQueuingDurationDataProvider extends DataProvider {
     // the relevant name, and further filtering by time interval.
     // Given the matching event, find a queuing event with the same tid and pid that fits
     // within the time interval.
-    Set<CompleteEvent> criticalPathEventsInThreads = new HashSet<>();
+    HashMultimap<PidTidKey, CompleteEvent> criticalPathEventsInThreads = HashMultimap.create();
     if (bazelProfile.getCriticalPath().isEmpty()) {
       return new CriticalPathQueuingDuration(EMPTY_REASON);
     }
+    /*
+     * Key: critical action path event name.
+     * Value: the same critical action path, but in event form.
+     * Used to efficiently look up critical path events by their parsed name.
+     */
+    HashMap<String, CompleteEvent> cPathActionNameToSelfEvent = new HashMap<>();
+    /*
+     * Key: critical action path event name.
+     * Values: all profile 'action processing' events that matched by name with the critical path
+     *  counterpart.
+     * Used to keep track, for each critical path event, all the candidates that could be used to
+     * find its real process and thread IDs.
+     */
+    HashMultimap<String, CompleteEvent> cPathActionNameToEventCandidates = HashMultimap.create();
+    /*
+     * Key: PidTidKey (process id and thread id in record form) of the remote queuing event
+     * Value: The remote queuing event
+     * This is used to efficiently match between a critical path event with the remote queuing
+     * event, by the process and thread IDs.
+     */
+    HashMultimap<PidTidKey, CompleteEvent> remoteQueuingEvents = HashMultimap.create();
+
+    for (var cPathEvent : bazelProfile.getCriticalPath().get().getCompleteEvents()) {
+      if (Strings.isNullOrEmpty(cPathEvent.name)) {
+        continue;
+      }
+      Matcher m = CRITICAL_PATH_TO_EVENT_NAME.matcher(cPathEvent.name);
+      if (!m.matches()) {
+        continue;
+      }
+      var eventNameToFind = m.group(1);
+      cPathActionNameToSelfEvent.put(eventNameToFind, cPathEvent);
+    }
+
+    // This loop is extremely expensive. Make sure we only perform it once!
     bazelProfile
-        .getCriticalPath()
-        .get()
-        .getCompleteEvents()
+        .getThreads()
         .forEach(
-            (criticalPathEvent) -> {
-              Matcher m = CRITICAL_PATH_TO_EVENT_NAME.matcher(criticalPathEvent.name);
-              if (m.matches()) {
-                String eventNameToFind = m.group(1);
-                bazelProfile
-                    .getThreads()
-                    .flatMap((thread) -> thread.getCompleteEvents().stream())
-                    // Name should match, and event interval should be contained in
-                    // criticalPathEvent interval.
-                    .filter(
-                        (event) ->
-                            BazelProfileConstants.CAT_ACTION_PROCESSING.equals(event.category)
-                                && eventNameToFind.equals(event.name)
-                                // If "action processing" is the first event, the timestamp
-                                // may be slightly out of sync with the critical path event.
-                                && (criticalPathEvent.start.almostEquals(event.start)
-                                    ||
-                                    // It may not be the first event, e.g.
-                                    // "action dependency checking" may be reported before
-                                    criticalPathEvent.start.compareTo(event.start) > 0)
-                                // Keep this always-true-condition for documentation purposes!
-                                // We have found cases where the end time of the critical path
-                                // event is less than the end time of the processing event.
-                                // This might be a bug / inconsistency in Bazel profile writing.
-                                && (true
-                                    || criticalPathEvent.end.almostEquals(event.end)
-                                    || criticalPathEvent.end.compareTo(event.end) > 0))
-                    // We expect to find just one event, but this may not be true for more
-                    // generic action names. Sort all thus far matching events to find the best
-                    // match.
-                    .sorted(
-                        (a, b) -> {
-                          boolean aWithinBounds =
-                              criticalPathEvent.end.almostEquals(a.end)
-                                  || criticalPathEvent.end.compareTo(a.end) > 0;
-                          boolean bWithinBounds =
-                              criticalPathEvent.end.almostEquals(b.end)
-                                  || criticalPathEvent.end.compareTo(b.end) > 0;
-                          if (aWithinBounds && bWithinBounds) {
-                            // Both events within bounds, prefer the longer one.
-                            return b.duration.compareTo(a.duration);
-                          }
-                          // If one of the events is within the bounds, prefer it.
-                          if (aWithinBounds) {
-                            return -1;
-                          }
-                          if (bWithinBounds) {
-                            return 1;
-                          }
-                          // Neither event within bounds, prefer the one that extends the bounds
-                          // least.
-                          return a.end.compareTo(b.end);
-                        })
-                    .limit(1)
-                    .forEach(
-                        e -> {
-                          // As we could not check the end boundary above, adjust the duration here,
-                          // so that we can ensure queuing events do not exceed the boundaries of
-                          // the critical path entry.
-                          Timestamp end =
-                              Timestamp.ofMicros(
-                                  Math.min(e.end.getMicros(), criticalPathEvent.end.getMicros()));
-                          criticalPathEventsInThreads.add(
-                              new CompleteEvent(
-                                  e.name,
-                                  e.category,
-                                  e.start,
-                                  TimeUtil.getDurationBetween(e.start, end),
-                                  e.threadId,
-                                  e.processId,
-                                  e.args));
-                        });
+            thread -> {
+              for (var event : thread.getCompleteEvents()) {
+                if (Strings.isNullOrEmpty(event.category)) {
+                  continue;
+                }
+                switch (event.category) {
+                  case BazelProfileConstants.CAT_ACTION_PROCESSING -> {
+                    var cPathEvent = cPathActionNameToSelfEvent.get(event.name);
+                    if (cPathEvent == null) {
+                      continue;
+                    }
+                    // Found an event that matches a critical path event by name. Add it to the
+                    // critical
+                    // path event's list of candidates for later.
+                    cPathActionNameToEventCandidates.put(event.name, event);
+                  }
+                  case BazelProfileConstants.CAT_REMOTE_EXECUTION_QUEUING_TIME -> {
+                    // We'll need to iterate through these later to sum the queuing time. Keep track
+                    // of this
+                    // to avoid having to iterate through the full profile again.
+                    remoteQueuingEvents.put(new PidTidKey(event.processId, event.threadId), event);
+                  }
+                  default -> {}
+                }
               }
             });
-    Duration duration =
-        bazelProfile
-            .getThreads()
-            .flatMap((thread) -> thread.getCompleteEvents().stream())
-            // Restrict to queuing events.
-            .filter(
-                (event) ->
-                    BazelProfileConstants.CAT_REMOTE_EXECUTION_QUEUING_TIME.equals(event.category))
-            // Restrict to events that are contained in one of the critical path events.
-            .filter(
-                (event) ->
-                    criticalPathEventsInThreads.stream()
-                        .anyMatch(
-                            (cpEvent) ->
-                                cpEvent.threadId == event.threadId
-                                    && cpEvent.processId == event.processId
-                                    && (cpEvent.start.compareTo(event.start) <= 0)
-                                    && (event.end.almostEquals(cpEvent.end)
-                                        || (event.end.compareTo(cpEvent.end) <= 0))))
-            .map((event) -> event.duration)
-            .reduce(Duration.ZERO, Duration::plus);
+
+    // For each critical path event, loop through its list of candidates that matched by name.
+    // This is used to get the correct thread ID and process ID that will later be matched up to
+    // the remote queuing events, to calculate critical path queuing.
+    for (var cPathEventName : cPathActionNameToEventCandidates.keySet()) {
+      var cPathEvent = cPathActionNameToSelfEvent.get(cPathEventName);
+      if (cPathEvent == null) {
+        continue;
+      }
+
+      @Nullable CompleteEvent found = null;
+      var foundWithinBounds = false;
+      for (CompleteEvent event : cPathActionNameToEventCandidates.get(cPathEventName)) {
+        // If "action processing" is the first event, the timestamp
+        // may be slightly out of sync with the critical path event.
+        //
+        // It may not be the first event, e.g.
+        // "action dependency checking" may be reported before
+        if (!cPathEvent.start.almostEquals(event.start)
+            && cPathEvent.start.compareTo(event.start) <= 0) {
+          continue;
+        }
+        // We have found cases where the end time of the critical path event is less than the end
+        // time of the processing event. This might be a bug / inconsistency in Bazel profile
+        // writing.
+        if (!cPathEvent.end.almostEquals(event.end) && cPathEvent.end.compareTo(event.end) <= 0) {
+          continue;
+        }
+
+        if (found == null) {
+          found = event;
+          foundWithinBounds =
+              cPathEvent.end.almostEquals(found.end) || cPathEvent.end.compareTo(found.end) > 0;
+          continue;
+        }
+
+        // We expect to find just one event, but this may not be true for more generic action
+        // names. Sort all thus far matching events to find the best match.
+        var eventWithinBounds =
+            cPathEvent.end.almostEquals(event.end) || cPathEvent.end.compareTo(event.end) > 0;
+
+        if (foundWithinBounds && eventWithinBounds) {
+          // Both events within bounds, prefer the longer one.
+          if (event.duration.compareTo(found.duration) > 0) {
+            found = event;
+            foundWithinBounds = true;
+          }
+          continue;
+        }
+        // If one of the events is within the bounds, prefer it.
+        if (eventWithinBounds) {
+          found = event;
+          foundWithinBounds = true;
+          continue;
+        }
+        // Neither event within bounds, prefer the one that extends the bounds
+        // least.
+        if (found.end.compareTo(event.end) < 0) {
+          found = event;
+          foundWithinBounds = false;
+        }
+      }
+      if (found != null) {
+        // As we could not check the end boundary above, adjust the duration here,
+        // so that we can ensure queuing events do not exceed the boundaries of
+        // the critical path entry.
+        Timestamp end =
+            Timestamp.ofMicros(Math.min(found.end.getMicros(), cPathEvent.end.getMicros()));
+        criticalPathEventsInThreads.put(
+            new PidTidKey(found.processId, found.threadId),
+            new CompleteEvent(
+                found.name,
+                found.category,
+                found.start,
+                TimeUtil.getDurationBetween(found.start, end),
+                found.threadId,
+                found.processId,
+                found.args));
+      }
+    }
+
+    Duration duration = Duration.ZERO;
+    for (var remoteQueuingEventEntry : remoteQueuingEvents.entries()) {
+      var remoteQueuingEvent = remoteQueuingEventEntry.getValue();
+      boolean found = false;
+      for (var criticalPathEventInThread :
+          criticalPathEventsInThreads.get(remoteQueuingEventEntry.getKey())) {
+        if (criticalPathEventInThread.start.compareTo(remoteQueuingEvent.start) <= 0
+            && (remoteQueuingEvent.end.almostEquals(criticalPathEventInThread.end)
+                || (remoteQueuingEvent.end.compareTo(criticalPathEventInThread.end) <= 0))) {
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        duration = duration.plus(remoteQueuingEvent.duration);
+      }
+    }
     return new CriticalPathQueuingDuration(duration);
   }
+
+  private record PidTidKey(int pid, int tid) {}
 }

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
@@ -189,9 +189,8 @@ public class CriticalPathQueuingDurationDataProvider extends DataProvider {
         }
         // Neither event within bounds, prefer the one that extends the bounds
         // least.
-        if (found.end.compareTo(event.end) < 0) {
+        if (!foundWithinBounds && found.end.compareTo(event.end) < 0) {
           found = event;
-          foundWithinBounds = false;
         }
       }
       if (found != null) {

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
@@ -156,7 +156,9 @@ public class CriticalPathQueuingDurationDataProvider extends DataProvider {
         // We have found cases where the end time of the critical path event is less than the end
         // time of the processing event. This might be a bug / inconsistency in Bazel profile
         // writing.
-        if (false && (!cPathEvent.end.almostEquals(event.end) && cPathEvent.end.compareTo(event.end) <= 0)) {
+        if (false
+            && (!cPathEvent.end.almostEquals(event.end)
+                && cPathEvent.end.compareTo(event.end) <= 0)) {
           continue;
         }
 

--- a/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
+++ b/analyzer/java/com/engflow/bazel/invocation/analyzer/dataproviders/remoteexecution/CriticalPathQueuingDurationDataProvider.java
@@ -175,7 +175,6 @@ public class CriticalPathQueuingDurationDataProvider extends DataProvider {
           // Both events within bounds, prefer the longer one.
           if (event.duration.compareTo(found.duration) > 0) {
             found = event;
-            foundWithinBounds = true;
           }
           continue;
         }

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BUILD
@@ -14,6 +14,7 @@ java_test(
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/time",
         "//analyzer/java/com/engflow/bazel/invocation/analyzer/traceeventformat",
         "//analyzer/javatests/com/engflow/bazel/invocation/analyzer:test_base",
+        "//third_party/gson",
         "//third_party/guava",
         "//third_party/junit",
         "//third_party/truth",

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileTest.java
@@ -37,12 +37,10 @@ import com.engflow.bazel.invocation.analyzer.time.TimeUtil;
 import com.engflow.bazel.invocation.analyzer.time.Timestamp;
 import com.engflow.bazel.invocation.analyzer.traceeventformat.CompleteEvent;
 import com.engflow.bazel.invocation.analyzer.traceeventformat.TraceEventFormatConstants;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.gson.JsonObject;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.Test;
@@ -143,47 +141,45 @@ public class BazelProfileTest extends UnitTestBase {
   public void parseCriticalPath() throws Exception {
     var name = "CPP";
     var want =
-        new ProfileThread(
-            new ThreadId(1, 1),
-            BazelProfileConstants.THREAD_CRITICAL_PATH,
-            0,
-            ImmutableList.of(),
-            ImmutableList.of(),
-            Lists.newArrayList(
-                new CompleteEvent(
-                    name,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(11),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of()),
-                new CompleteEvent(
-                    name,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(21),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of()),
-                new CompleteEvent(
-                    name,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(31),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of()),
-                new CompleteEvent(
-                    name,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(50),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of())),
-            ImmutableMap.of(),
-            ImmutableMap.of());
+        new ProfileThread.Builder()
+            .setThreadId(new ThreadId(1, 1))
+            .setName(BazelProfileConstants.THREAD_CRITICAL_PATH)
+            .setSortIndex(0)
+            .setCompleteEvents(
+                List.of(
+                    new CompleteEvent(
+                        name,
+                        BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                        Timestamp.ofMicros(11),
+                        TimeUtil.getDurationForMicros(10),
+                        1,
+                        1,
+                        ImmutableMap.of()),
+                    new CompleteEvent(
+                        name,
+                        BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                        Timestamp.ofMicros(21),
+                        TimeUtil.getDurationForMicros(10),
+                        1,
+                        1,
+                        ImmutableMap.of()),
+                    new CompleteEvent(
+                        name,
+                        BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                        Timestamp.ofMicros(31),
+                        TimeUtil.getDurationForMicros(10),
+                        1,
+                        1,
+                        ImmutableMap.of()),
+                    new CompleteEvent(
+                        name,
+                        BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                        Timestamp.ofMicros(50),
+                        TimeUtil.getDurationForMicros(10),
+                        1,
+                        1,
+                        ImmutableMap.of())))
+            .build();
 
     var profile =
         useProfile(
@@ -351,147 +347,91 @@ public class BazelProfileTest extends UnitTestBase {
   }
 
   @Test
-  public void addEventShouldThrowOnSortedProfileThread() throws Exception {
-    var name = "CPP";
-    var thread =
-        new ProfileThread(
-            new ThreadId(1, 1),
-            BazelProfileConstants.THREAD_CRITICAL_PATH,
-            0,
-            ImmutableList.of(),
-            ImmutableList.of(),
-            Lists.newArrayList(
-                new CompleteEvent(
-                    name,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(11),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of()),
-                new CompleteEvent(
-                    name,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(21),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of()),
-                new CompleteEvent(
-                    name,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(31),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of()),
-                new CompleteEvent(
-                    name,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(50),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of())),
-            ImmutableMap.of(),
-            ImmutableMap.of());
-
-    // Getting the completeEvents from the thread will trigger them to be sorted.
-    var sorted = thread.getCompleteEvents();
-    // At this point, any further attempts at modifying the thread should throw an ISE, as this
-    // would break the sorting that was previously done.
-    var exception =
-        assertThrows(IllegalStateException.class, () -> thread.addEvent(new JsonObject()));
-    assertThat(exception)
-        .hasMessageThat()
-        .isEqualTo("Cannot add event, Bazel profile thread has been sorted!");
-  }
-
-  @Test
   public void isMainThreadShouldReturnFalseOnUnnamedProfileThread() {
-    ProfileThread thread = new ProfileThread(new ThreadId(0, 0));
+    ProfileThread thread = new ProfileThread.Builder().setThreadId(new ThreadId(0, 0)).build();
     assertThat(BazelProfile.isMainThread(thread)).isFalse();
   }
 
   @Test
   public void isMainThreadShouldReturnFalseOnOtherProfileThread() {
     ProfileThread thread =
-        new ProfileThread(
-            new ThreadId(0, 0), "skyframe-evaluator-1", null, null, null, null, null, null);
+        new ProfileThread.Builder()
+            .setThreadId(new ThreadId(0, 0))
+            .setName("skyframe-evaluator-1")
+            .build();
     assertThat(BazelProfile.isMainThread(thread)).isFalse();
   }
 
   @Test
   public void isMainThreadShouldReturnTrueOnNewName() {
     ProfileThread thread =
-        new ProfileThread(new ThreadId(0, 0), "Main Thread", null, null, null, null, null, null);
+        new ProfileThread.Builder().setThreadId(new ThreadId(0, 0)).setName("Main Thread").build();
     assertThat(BazelProfile.isMainThread(thread)).isTrue();
   }
 
   @Test
   public void isMainThreadShouldReturnTrueOnOldName() {
     ProfileThread thread =
-        new ProfileThread(new ThreadId(0, 0), "grpc-command-3", null, null, null, null, null, null);
+        new ProfileThread.Builder()
+            .setThreadId(new ThreadId(0, 0))
+            .setName("grpc-command-3")
+            .build();
     assertThat(BazelProfile.isMainThread(thread)).isTrue();
   }
 
   @Test
   public void isGarbageCollectorThreadShouldReturnFalseOnEmptyProfileThread() {
-    ProfileThread thread = new ProfileThread(new ThreadId(0, 0));
+    ProfileThread thread = new ProfileThread.Builder().setThreadId(new ThreadId(0, 0)).build();
     assertThat(BazelProfile.isGarbageCollectorThread(thread)).isFalse();
   }
 
   @Test
   public void isGarbageCollectorShouldReturnFalseOnOtherProfileThread() {
     ProfileThread thread =
-        new ProfileThread(
-            new ThreadId(0, 0), "skyframe-evaluator-1", null, null, null, null, null, null);
+        new ProfileThread.Builder()
+            .setThreadId(new ThreadId(0, 0))
+            .setName("skyframe-evaluator-1")
+            .build();
     assertThat(BazelProfile.isGarbageCollectorThread(thread)).isFalse();
   }
 
   @Test
   public void isGarbageCollectorShouldReturnFalseOnGCThreadWithoutGCEvents() {
     ProfileThread thread =
-        new ProfileThread(
-            new ThreadId(0, 0),
-            "Garbage Collector",
-            null,
-            null,
-            null,
-            Lists.newArrayList(
-                new CompleteEvent(
-                    null,
-                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
-                    Timestamp.ofMicros(11),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of())),
-            null,
-            null);
+        new ProfileThread.Builder()
+            .setThreadId(new ThreadId(0, 0))
+            .setName("Garbage Collector")
+            .setCompleteEvents(
+                List.of(
+                    new CompleteEvent(
+                        null,
+                        BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                        Timestamp.ofMicros(11),
+                        TimeUtil.getDurationForMicros(10),
+                        1,
+                        1,
+                        ImmutableMap.of())))
+            .build();
     assertThat(BazelProfile.isGarbageCollectorThread(thread)).isFalse();
   }
 
   @Test
   public void isGarbageCollectorShouldReturnTrueOnThreadWithGC() {
     ProfileThread thread =
-        new ProfileThread(
-            new ThreadId(0, 0),
-            "Foo Thread",
-            null,
-            null,
-            null,
-            Lists.newArrayList(
-                new CompleteEvent(
-                    null,
-                    BazelProfileConstants.CAT_GARBAGE_COLLECTION,
-                    Timestamp.ofMicros(11),
-                    TimeUtil.getDurationForMicros(10),
-                    1,
-                    1,
-                    ImmutableMap.of())),
-            null,
-            null);
+        new ProfileThread.Builder()
+            .setThreadId(new ThreadId(0, 0))
+            .setName("Foo Thread")
+            .setCompleteEvents(
+                List.of(
+                    new CompleteEvent(
+                        null,
+                        BazelProfileConstants.CAT_GARBAGE_COLLECTION,
+                        Timestamp.ofMicros(11),
+                        TimeUtil.getDurationForMicros(10),
+                        1,
+                        1,
+                        ImmutableMap.of())))
+            .build();
     assertThat(BazelProfile.isGarbageCollectorThread(thread)).isTrue();
   }
 

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileTest.java
@@ -353,7 +353,7 @@ public class BazelProfileTest extends UnitTestBase {
   @Test
   public void addEventShouldThrowOnSortedProfileThread() throws Exception {
     var name = "CPP";
-    var want =
+    var thread =
         new ProfileThread(
             new ThreadId(1, 1),
             BazelProfileConstants.THREAD_CRITICAL_PATH,
@@ -397,11 +397,11 @@ public class BazelProfileTest extends UnitTestBase {
             ImmutableMap.of());
 
     // Getting the completeEvents from the thread will trigger them to be sorted.
-    var sorted = want.getCompleteEvents();
+    var sorted = thread.getCompleteEvents();
     // At this point, any further attempts at modifying the thread should throw an ISE, as this
     // would break the sorting that was previously done.
     var exception =
-        assertThrows(IllegalStateException.class, () -> want.addEvent(new JsonObject()));
+        assertThrows(IllegalStateException.class, () -> thread.addEvent(new JsonObject()));
     assertThat(exception)
         .hasMessageThat()
         .isEqualTo("Cannot add event, Bazel profile thread has been sorted!");

--- a/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileTest.java
+++ b/analyzer/javatests/com/engflow/bazel/invocation/analyzer/bazelprofile/BazelProfileTest.java
@@ -40,6 +40,7 @@ import com.engflow.bazel.invocation.analyzer.traceeventformat.TraceEventFormatCo
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.gson.JsonObject;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.IntStream;
@@ -347,6 +348,63 @@ public class BazelProfileTest extends UnitTestBase {
 
     assertThat(profile.getActionCounts().isPresent()).isTrue();
     assertThat(profile.getActionCounts().get().size()).isEqualTo(201);
+  }
+
+  @Test
+  public void addEventShouldThrowOnSortedProfileThread() throws Exception {
+    var name = "CPP";
+    var want =
+        new ProfileThread(
+            new ThreadId(1, 1),
+            BazelProfileConstants.THREAD_CRITICAL_PATH,
+            0,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            Lists.newArrayList(
+                new CompleteEvent(
+                    name,
+                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                    Timestamp.ofMicros(11),
+                    TimeUtil.getDurationForMicros(10),
+                    1,
+                    1,
+                    ImmutableMap.of()),
+                new CompleteEvent(
+                    name,
+                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                    Timestamp.ofMicros(21),
+                    TimeUtil.getDurationForMicros(10),
+                    1,
+                    1,
+                    ImmutableMap.of()),
+                new CompleteEvent(
+                    name,
+                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                    Timestamp.ofMicros(31),
+                    TimeUtil.getDurationForMicros(10),
+                    1,
+                    1,
+                    ImmutableMap.of()),
+                new CompleteEvent(
+                    name,
+                    BazelProfileConstants.CAT_CRITICAL_PATH_COMPONENT,
+                    Timestamp.ofMicros(50),
+                    TimeUtil.getDurationForMicros(10),
+                    1,
+                    1,
+                    ImmutableMap.of())),
+            ImmutableMap.of(),
+            ImmutableMap.of());
+
+    // Getting the completeEvents from the thread will trigger them to be sorted.
+    var sorted = want.getCompleteEvents();
+    // At this point, any further attempts at modifying the thread should throw an ISE, as this
+    // would break the sorting that was previously done.
+    var exception =
+        assertThrows(IllegalStateException.class, () -> want.addEvent(new JsonObject()));
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo("Cannot add event, Bazel profile thread has been sorted!");
   }
 
   @Test


### PR DESCRIPTION
This provider currently performs several full loops over the Bazel profiles. This results in it not scaling well performance and memory consumption-wise.

Also at the profile level, some expensive copying and re-sorting of bazel profile data is performed each time it is requested by the providers.

Allocations:
<img width="3079" height="828" alt="image" src="https://github.com/user-attachments/assets/164a37a3-8193-42fb-a860-6bc961d277ac" />

CPU:
<img width="3098" height="988" alt="image" src="https://github.com/user-attachments/assets/13ed0e2c-f0b4-42d4-8562-04c000f76325" />

This PR aims to reduce the amount of loops over the data in `CriticalPathQueuingDurationDataProvider` to just one, enabling it to scale better. 
Also, cleans the expensive copying and re-sorting of bazel profile data each time it is requested, by switching thread building to a Builder pattern, which sorts the entries internally as needed before returning the immutable sorted result.

Thanks to @iamricard for doing a lot of the initial work and investigation on this (the branch was opened in another repository so I didn't know how to cleanly credit him in the commits I moved over to here)